### PR TITLE
61-Fixing invalid characters in get base message

### DIFF
--- a/src/main/resources/basemessages.properties
+++ b/src/main/resources/basemessages.properties
@@ -2,7 +2,7 @@ basemessages.1=Function completed successfully
 
 basemessages.2=Partial success: Function completed successfully but some growing data-object data-nodes were not returned.
 basemessages.-401=The input template MUST contain a plural root element.
-basemessages.-402=The value of the OptionsIn keyword of ‘maxReturnNodes’ MUST be greater than zero.
+basemessages.-402=The value of the OptionsIn keyword of 'maxReturnNodes' MUST be greater than zero.
 
 basemessages.-403=A template must include a default namespace declaration for the WITSML namespace.
 
@@ -29,12 +29,12 @@ basemessages.-419=For WMLS_DeleteFromStore, an empty non-recurring container-ele
 basemessages.-420=For WMLS_DeleteFromStore, an empty node must not be specified for a non-recurring element or attribute that is mandatory in the write schema.
 basemessages.-421=For WMLS_DeleteFromStore, a recurring element that is mandatory in the write schema must retain at least one occurrence after the deletion.
 basemessages.-422=For WMLS_GetBaseMsg, a non-empty value must be specified for ReturnValueIn.
-basemessages.-423=For WMLS_GetCap, the OptionsIn keyword ‘dataVersion’ must specify a Data Schema Version that is supported by the server as defined by WMLS_GetVersion.
-basemessages.-424=For WMLS_GetCap, the OptionsIn keyword ‘dataVersion’ must be specified.
-basemessages.-425=For WMLS_GetFromStore, the OptionsIn keyword ‘returnElements’ must not specify a value of “header- only” or “data-only” for a non-growing data-object.
+basemessages.-423=For WMLS_GetCap, the OptionsIn keyword 'dataVersion' must specify a Data Schema Version that is supported by the server as defined by WMLS_GetVersion.
+basemessages.-424=For WMLS_GetCap, the OptionsIn keyword 'dataVersion' must be specified.
+basemessages.-425=For WMLS_GetFromStore, the OptionsIn keyword 'returnElements' must not specify a value of “header- only” or “data-only” for a non-growing data-object.
 basemessages.-426=The input template must conform to the appropriate derived schema after uncompressing the string.
-basemessages.-427=The OptionsIn keyword ‘requestObjectSelectionCapability’ with a value other than ‘none’ must not be specified with any other OptionsIn keyword.
-basemessages.-428=If the OptionsIn keyword ‘requestObjectSelectionCapability’ is specified with a value other than ‘none’ then QueryIn must be the Minimum Query Template.
+basemessages.-427=The OptionsIn keyword 'requestObjectSelectionCapability' with a value other than 'none' must not be specified with any other OptionsIn keyword.
+basemessages.-428=If the OptionsIn keyword 'requestObjectSelectionCapability' is specified with a value other than 'none' then QueryIn must be the Minimum Query Template.
 basemessages.-429=For WMLS_GetFromStore, the logData section must not recur when retrieving data.
 basemessages.-430=A client must specify an item for data-item selection that the server supports.
 basemessages.-431=A client must specify an item (element or attribute) for data-object selection that the server supports.
@@ -49,7 +49,7 @@ basemessages.-439=When multiple selection criteria is are included in a recurrin
 basemessages.-440=The OptionsIn value must be a recognized keyword for that function.
 basemessages.-441=The value specified with an OptionsIn keyword must be a recognized value for that keyword.
 basemessages.-442=A client must not specify an OptionsIn keyword that is not supported by the server.
-basemessages.-443=The value of the uom attribute is must match an ‘annotation’ attribute from the WITSML Units Dictionary XML file.
+basemessages.-443=The value of the uom attribute is must match an 'annotation' attribute from the WITSML Units Dictionary XML file.
 basemessages.-444=The input template must not specify more than one data-object.
 basemessages.-445=For WMLS_UpdateInStore, new elements or attributes must not be empty.
 basemessages.-446=For WMLS_UpdateInStore, a uom attribute must not be specified unless its corresponding value is specified.
@@ -67,7 +67,7 @@ basemessages.-453=For WMLS_AddToStore and WMLS_UpdateInStore, the client must al
 
 basemessages.-454=For a particular WMLS_AddToStore call, a client must specify all growing data-object index data in the same unit of measure.
 basemessages.-455=All datum elements or attributes for indexes in a growing data-object must implicitly or explicitly point to the same wellDatum when adding or updating data.
-basemessages.-456=The client must not attempt to add or update more data than is allowed by the server’s maxDataNodes and maxDataPoints values.
+basemessages.-456=The client must not attempt to add or update more data than is allowed by the server's maxDataNodes and maxDataPoints values.
 
 basemessages.-457=If a column-identifier representing the index column is specified then it must be specified first in the data- column-list.
 basemessages.-458=For growing data-objects, a combination of depth and date-time structural-range indices must not be specified.

--- a/src/main/resources/servercap.properties
+++ b/src/main/resources/servercap.properties
@@ -8,4 +8,3 @@ wmls.name=John Smith
 wmls.supportUomConversion=true
 wmls.compressionMethod=gzip
 wmls.cascadedDelete=true
-wmls.growingTimeouts[0]={key1:'log',key2:12}


### PR DESCRIPTION
This PR resolves #62 .

There were invalid characters in the properties files that generated un-parseable SOAP strings.
Additionally there was an erroneous property in servercap after a refactor.