### PR TITLE
Drillflow 39 - WMLS_AddToStore endpoint skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ docs/build/
 .factorypath
 .project
 .settings
+**/.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,7 @@ compile:
 # package the application into an uber-jar
 package:  
 	mvn clean package
+
+# run
+run:  
+	java -jar target/server-0.0.1-SNAPSHOT.jar

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: compile
 
 # compile the application
 compile:  
-	mvn clean build
+	mvn clean compile
 
 # package the application into an uber-jar
 package:  

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ By default the service will be available at:
 
 `http://localhost:7070/Service/WMLS`
 
+#### Soap UI
 Execute the following SOAP query to get the version:
 ```xml
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="http://www.witsml.org/wsdl/120" xmlns:types="http://www.witsml.org/wsdl/120/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
@@ -72,6 +73,23 @@ By default the server should return the following response:
     </soap:Body>
   </soap:Envelope>
   ```
+
+#### Postman
+
+[Follow the instructions for postman here.](https://www.getpostman.com/docs/v6/postman/sending_api_requests/making_soap_requests)
+
+Use this as the endpoint address: `http://localhost:7070/Service/WMLS?wsdl`
+
+Use the following as the xml body:
+
+```xml
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns="http://www.witsml.org/wsdl/120">
+  <soapenv:Header/>
+  <soapenv:Body>
+     <ns:getVersion/>
+  </soapenv:Body>
+</soapenv:Envelope>
+```
 
 ### CVE Checking
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,9 @@
+all: build 
+
+# build the image
+build:  
+	docker build . -t hashmapinc/witsmlapi-server:latest
+
+# run a container
+run:  
+	docker run -p 7070:7070 hashmapinc/witsmlapi-server:latest

--- a/src/main/java/com/hashmapinc/tempus/witsml/server/api/IStore.java
+++ b/src/main/java/com/hashmapinc/tempus/witsml/server/api/IStore.java
@@ -28,6 +28,15 @@ import javax.xml.ws.ResponseWrapper;
 @SOAPBinding(style = SOAPBinding.Style.RPC)
 public interface IStore {
 
+    @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_AddToStore")
+    @RequestWrapper(targetNamespace = "http://www.witsml.org/message/120")
+    int addToStore(
+        @WebParam(partName = "WMLtypeIn") String WMLtypeIn,
+        @WebParam(partName = "XMLin") String XMLin,
+        @WebParam(partName = "OptionsIn") String OptionsIn,
+        @WebParam(partName = "CapabilitiesIn") String CapabilitiesIn
+    );
+
     @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_GetVersion")
     @RequestWrapper(targetNamespace = "http://www.witsml.org/message/120")
     String getVersion();

--- a/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -66,6 +66,17 @@ public class StoreImpl implements IStore {
 
 
     @Override
+    public int addToStore(
+        String WMLtypeIn,
+        String XMLin,
+        String OptionsIn,
+        String CapabilitiesIn
+    ) {
+        LOG.info("Executing addToStore");
+        return 1;
+    }
+
+    @Override
     public String getVersion() {
         LOG.info("Executing GetVersion");
         return version;

--- a/src/test/java/com/hashmapinc/tempus/witsml/server/api/WitsmlServerApplicationTests.java
+++ b/src/test/java/com/hashmapinc/tempus/witsml/server/api/WitsmlServerApplicationTests.java
@@ -37,6 +37,18 @@ public class WitsmlServerApplicationTests {
 	}
 
 	@Test
+	public void addToStore_shouldReturn1() {
+		assertThat(
+			this.witsmlServer.addToStore(
+				"WMLtypeIn",
+				"XMLin",
+				"OptionsIn",
+				"CapabilitiesIn"
+			)
+		).isEqualTo(1);
+	}
+
+	@Test
 	public void getVersionShouldReturnDefaultVersion(){
 		assertThat(this.witsmlServer.getVersion()).contains("1.3.1.1,1.4.1.1");
 	}


### PR DESCRIPTION
This PR includes:
- `.gitignore` DS_Store addition
- brand spankin' new `Makefile` for docker building
- WMLS_AddToStore implementation that just returns `1`
- simple test for WMLS_AddToStore implementation

This connects to #39 