### PR TITLE
Drillflow-66 - invalid operation name

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,41 +55,30 @@ By default the service will be available at:
 #### Soap UI
 Execute the following SOAP query to get the version:
 ```xml
-<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="http://www.witsml.org/wsdl/120" xmlns:types="http://www.witsml.org/wsdl/120/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-   <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-     <q1:WMLS_GetVersion xmlns:q1="http://www.witsml.org/message/120" />
-   </soap:Body>
- </soap:Envelope>
+<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns="http://www.witsml.org/message/120">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <ns:WMLS_GetVersion soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+   </soapenv:Body>
+</soapenv:Envelope>
 ```
  
 By default the server should return the following response:
  
  ```xml
- <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
     <soap:Body>
-      <ns1:WMLS_GetVersionResponse xmlns:ns1="http://www.witsml.org/wsdl/120">
-        <return xmlns:ns2="http://www.witsml.org/wsdl/120">1.3.1.1,1.4.1.1</return>
-      </ns1:WMLS_GetVersionResponse>
+        <ns1:WMLS_GetVersionResponse xmlns:ns1="http://www.witsml.org/wsdl/120">
+            <return xmlns:ns2="http://www.witsml.org/wsdl/120">1.3.1.1,1.4.1.1</return>
+        </ns1:WMLS_GetVersionResponse>
     </soap:Body>
-  </soap:Envelope>
+</soap:Envelope>
   ```
 
 #### Postman
 
-[Follow the instructions for postman here.](https://www.getpostman.com/docs/v6/postman/sending_api_requests/making_soap_requests)
-
-Use this as the endpoint address: `http://localhost:7070/Service/WMLS?wsdl`
-
-Use the following as the xml body:
-
-```xml
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns="http://www.witsml.org/wsdl/120">
-  <soapenv:Header/>
-  <soapenv:Body>
-     <ns:getVersion/>
-  </soapenv:Body>
-</soapenv:Envelope>
-```
+For Postman, use a POST query to the same URL as stated above with encoding type as `text/xml` and add a header with key `SOAPAction`and the value 
+`http://www.witsml.org/action/120/Store.WMLS_GetVersion`. Then you can use the same query as above.
 
 ### CVE Checking
 

--- a/src/main/java/com/hashmapinc/tempus/witsml/server/api/IStore.java
+++ b/src/main/java/com/hashmapinc/tempus/witsml/server/api/IStore.java
@@ -24,11 +24,11 @@ import javax.jws.soap.SOAPBinding;
 import javax.xml.ws.RequestWrapper;
 import javax.xml.ws.ResponseWrapper;
 
-@WebService(targetNamespace = "http://www.witsml.org/wsdl/120", name = "WMLS")
+@WebService(targetNamespace = "http://www.witsml.org/wsdl/120", name = "StoreSoapBinding")
 @SOAPBinding(style = SOAPBinding.Style.RPC)
 public interface IStore {
 
-    @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_AddToStore")
+    @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_AddToStore", operationName = "WMLS_AddToStore")
     @RequestWrapper(targetNamespace = "http://www.witsml.org/message/120")
     int addToStore(
         @WebParam(partName = "WMLtypeIn") String WMLtypeIn,
@@ -37,18 +37,18 @@ public interface IStore {
         @WebParam(partName = "CapabilitiesIn") String CapabilitiesIn
     );
 
-    @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_GetVersion")
+    @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_GetVersion", operationName = "WMLS_GetVersion")
     @RequestWrapper(targetNamespace = "http://www.witsml.org/message/120")
     String getVersion();
 
-    @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_GetCap")
+    @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_GetCap", operationName = "WMLS_GetCap")
     @RequestWrapper(targetNamespace = "http://www.witsml.org/message/120", localName = "Store.WMLS_GetCap")
     @ResponseWrapper(targetNamespace = "http://www.witsml.org/message/120",
                      className = "com.hashmapinc.tempus.witsml.server.api.model.WMLS_GetCapResponse")
     WMLS_GetCapResponse getCap(@WebParam(partName = "OptionsIn") String OptionsIn);
 
 
-    @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_GetBaseMsg")
+    @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_GetBaseMsg", operationName = "WMLS_GetBaseMsg")
     @RequestWrapper(targetNamespace = "http://www.witsml.org/message/120")
     String getBaseMsg(@WebParam(partName= "ReturnValueIn") Short ReturnValueIn);
 }

--- a/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -41,7 +41,7 @@ import javax.jws.WebService;
 import java.util.logging.Logger;
 
 @Service
-@WebService(serviceName = "StoreService", portName = "StoreSoapPort",
+@WebService(serviceName = "StoreSoapBinding", portName = "StoreSoapBindingSoap",
         targetNamespace = "http://www.witsml.org/wsdl/120",
         endpointInterface = "com.hashmapinc.tempus.witsml.server.api.IStore")
 public class StoreImpl implements IStore {

--- a/src/main/java/com/hashmapinc/tempus/witsml/server/api/model/WMLS_GetCapResponse.java
+++ b/src/main/java/com/hashmapinc/tempus/witsml/server/api/model/WMLS_GetCapResponse.java
@@ -20,7 +20,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlRootElement(name="WMLS_GetCapResponse)")
+@XmlRootElement(name="WMLS_GetCapResponse")
 public class WMLS_GetCapResponse {
 
     private Short Result;


### PR DESCRIPTION
This PR resolves #66 by addressing the invalid operation names. There are now legal operation names. The Readme has been updated, and an invalid WMLS_GetCapResponse name was addressed. SOAPUI can now import the Drillflow WSDL directly.