### PR TITLE
df-70 -> WitsmlUtil.parseOptionsIn utility method

### DIFF
--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/WitsmlUtil.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/WitsmlUtil.java
@@ -21,9 +21,7 @@ import java.util.logging.Logger;
 
 
 /** 
- * StoreObject is a wrapper class around the 4 possible store objects
- * supported by Drillflow right now: Well, WellBore, Trajectory, and 
- * Log (depth and time)
+ * General static util methods for witsml stuff
  */
 public class WitsmlUtil {
     // get logger

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/WitsmlUtil.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/WitsmlUtil.java
@@ -72,7 +72,7 @@ public class WitsmlUtil {
      */
     public static HashMap<String,String> parseOptionsIn(
         String optionsIn
-    ) throws Exception {
+    ) {
         LOG.info("trying to parse optionsIn...");
 
         //parse the string

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/WitsmlUtil.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/WitsmlUtil.java
@@ -15,7 +15,10 @@
  */
 package com.hashmapinc.tempus.witsml;
 
+import java.util.HashMap;
+import java.util.Arrays;
 import java.util.logging.Logger;
+
 
 /** 
  * StoreObject is a wrapper class around the 4 possible store objects
@@ -60,5 +63,27 @@ public class WitsmlUtil {
         // successfully parsed version. Return here
         LOG.info("version parsed from raw xml is " + version);
         return version;
+    }
+
+    /**
+     * this method parses a witsml optionsIn string into a String->String map
+     * 
+     * @param optionsIn - String with witsml optionsIn - see witsml spec for format
+     * 
+     * @return map - Map<String, String> containing Key-values parsed from options in
+     */
+    public static HashMap<String,String> parseOptionsIn(
+        String optionsIn
+    ) throws Exception {
+        LOG.info("trying to parse optionsIn...");
+
+        //parse the string
+        HashMap<String, String> map = new HashMap<>();
+        Arrays.stream(optionsIn.split(";")).forEach(optionString -> {
+            String[] option = optionString.split("=");
+            map.put(option[0], option[1]);
+        });
+
+        return map;
     }
 }

--- a/df-server/src/test/java/com/hashmapinc/tempus/witsml/WitsmlUtilTests.java
+++ b/df-server/src/test/java/com/hashmapinc/tempus/witsml/WitsmlUtilTests.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright © 2018-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hashmapinc.tempus.witsml;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class WitsmlUtilTests {
+
+	@Test
+	public void parseOptionsIn_shouldParseValidInputString() {
+        // create input
+        String optionsIn = 
+            "coolOption=coolValue;awesomeOption=awesomeValue;chillOption=chillValue";
+        
+        // create correct map
+        HashMap<String,String> correctMap = new HashMap<>();
+        correctMap.put("coolOption", "coolValue");
+        correctMap.put("awesomeOption", "awesomeValue");
+        correctMap.put("chillOption", "chillValue");
+
+        // get parsed map
+        HashMap<String,String> parsedMap = WitsmlUtil.parseOptionsIn(optionsIn);
+
+        // compare the correct and parsed maps. They should be equal.
+        boolean mapsAreEqual = parsedMap.equals(correctMap);
+        assertThat(mapsAreEqual).isEqualTo(true);
+
+        // create an incorrect map
+        HashMap<String,String> incorrectMap = correctMap;
+        incorrectMap.put("incorrectOption", "incorrectValue");
+
+        // compare the incorrect and parsed maps. They should not be equal.
+        mapsAreEqual = parsedMap.equals(incorrectMap);
+        assertThat(mapsAreEqual).isEqualTo(false);
+    }
+}


### PR DESCRIPTION
This PR includes:
- addition of a static parser method in `WitsmlUtil` to convert valid `OptionsIn` witsml strings to `HashMap<String, String>` objects
- addition of testing suite for the `OptionsIn` parser utility method

This connects to #70 