### PR TITLE
df-50 and df-51 -> implement abstract valve translator / valve delegator

### DIFF
--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/valve/AbstractDelegator.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/valve/AbstractDelegator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2018-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hashmapinc.tempus.witsml.valve;
 
 /**

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/valve/AbstractDelegator.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/valve/AbstractDelegator.java
@@ -1,0 +1,9 @@
+package com.hashmapinc.tempus.witsml.valve;
+
+/**
+ * This class is meant to add structure and default
+ * functionality to any valve delegator
+ */
+public abstract class AbstractDelegator {
+    
+}

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/valve/AbstractTranslator.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/valve/AbstractTranslator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2018-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hashmapinc.tempus.witsml.valve;
 
 /**

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/valve/AbstractTranslator.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/valve/AbstractTranslator.java
@@ -1,0 +1,9 @@
+package com.hashmapinc.tempus.witsml.valve;
+
+/**
+ * This class is meant to add structure and default
+ * functionality to any valve translator
+ */
+public abstract class AbstractTranslator {
+
+}


### PR DESCRIPTION
This PR includes:
- implementation of the `AbstractTranslator` in `com.hashmapinc.tempus.witsml.valve` package
- implementation of the `AbstractDelegator` in `com.hashmapinc.tempus.witsml.valve` pacage

This connects to #50 
This connects to #51