### PR TITLE
df-89 -> creation of the QueryContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ docs/build/
 .factorypath
 .project
 .settings
+.vscode
 **/.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+all: compile 
+
+# compile the application
+compile:  
+	mvn -q clean compile
+
+# package the application into an uber-jar with tests
+package:  
+	mvn -q clean package
+
+# package the application into an uber-jar without tests
+fastPackage:  
+	mvn -q clean package -DskipTests=true
+
+# clean
+clean:
+	mvn -q clean
+
+# test
+test: clean
+	mvn test

--- a/df-server/pom.xml
+++ b/df-server/pom.xml
@@ -63,12 +63,6 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <!--
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-        -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
@@ -121,6 +115,13 @@
             <groupId>com.hashmapinc.tempus</groupId>
             <artifactId>WitsmlObjects</artifactId>
             <version>1.1.1</version>
+        </dependency>
+
+        <!-- import the valves -->
+        <dependency>
+            <groupId>com.hashmapinc.tempus.witsml</groupId>
+            <artifactId>df-valve</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/QueryContext.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/QueryContext.java
@@ -1,4 +1,51 @@
+/**
+ * Copyright © 2018-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hashmapinc.tempus.witsml.server.api;
 
+import java.util.Map;
+
+import com.hashmapinc.tempus.witsml.WitsmlUtil;
+
+/**
+ * QueryContext is used to hold the state of an individual query
+ * to DRILLFLOW and is passed to Valves for query execution
+ */
 public class QueryContext {
+    public final String CLIENT_VERSION; // the WITSML version used by the client that sent the query
+    public final String OBJECT_TYPE; // the type of WITSML object being queried for
+    public final Map<String, String> OPTIONS_IN; // MAP of options_in key/value pairs
+    public final String QUERY_XML; // the raw WITSML xml query sent from the client
+
+    /**
+     * 
+     * @param clientVersion - the WITSML version used by the client that sent the query
+     * @param objectType - the type of WITSML object being queried for
+     * @param optionsIn - String holding the options in for the query per the WITSML 1.3/1.4 specs
+     * @param queryXML - String holding the raw xml query sent from the client
+     */
+    public QueryContext(
+        String clientVersion,
+        String objectType,
+        String optionsIn,
+        String queryXML
+    ) {
+        // instantiate values
+        this.CLIENT_VERSION = clientVersion;
+        this.OBJECT_TYPE = objectType;
+        this.OPTIONS_IN = WitsmlUtil.parseOptionsIn(optionsIn);
+        this.QUERY_XML = queryXML; 
+    }
 }

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/QueryContext.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/QueryContext.java
@@ -45,7 +45,7 @@ public class QueryContext {
         // instantiate values
         this.CLIENT_VERSION = clientVersion;
         this.OBJECT_TYPE = objectType;
-        this.OPTIONS_IN = WitsmlUtil.parseOptionsIn(optionsIn);
+        this.OPTIONS_IN = WitsmlUtil.parseOptionsIn(optionsIn); // parse this in the constructor to ensure it is immutable
         this.QUERY_XML = queryXML; 
     }
 }

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/QueryContext.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/QueryContext.java
@@ -1,0 +1,4 @@
+package com.hashmapinc.tempus.witsml.server.api;
+
+public class QueryContext {
+}

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -16,12 +16,15 @@
 package com.hashmapinc.tempus.witsml.server.api;
 
 import com.hashmapinc.tempus.witsml.server.WitsmlApiConfig;
+import com.hashmapinc.tempus.witsml.server.api.QueryContext;
 import com.hashmapinc.tempus.witsml.server.api.model.WMLS_GetCapResponse;
 import com.hashmapinc.tempus.witsml.server.api.model.WMLS_GetFromStoreResponse;
 import com.hashmapinc.tempus.witsml.server.api.model.cap.ServerCap;
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.witsml.WitsmlUtil;
 import com.hashmapinc.tempus.witsml.WitsmlObjectParser;
+import com.hashmapinc.tempus.witsml.valve.AbstractValve;
+import com.hashmapinc.tempus.witsml.valve.ValveFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -130,14 +133,27 @@ public class StoreImpl implements IStore {
     ) {
         LOG.info("Executing GetFromStore");
         WMLS_GetFromStoreResponse resp = new WMLS_GetFromStoreResponse();
-        resp.setSuppMsgOut("");
+
         try {
-            String data = "test";
-            resp.setXMLout(data);
+            // construct query context
+            String clientVersion = WitsmlUtil.getVersionFromXML(QueryIn);
+            QueryContext qc = new QueryContext(
+                clientVersion,
+                WMLtypeIn,
+                OptionsIn,
+                QueryIn
+            );
+
+            // execute query
+            AbstractValve valve = ValveFactory.buildValve("DoT"); //TODO: don't hard code this, don't access locally (need a class field for this)
+
+            // populate response
+            resp.setSuppMsgOut("");
             resp.setResult((short)1);
+            resp.setXMLout("");
         } catch (Exception e) {
             resp.setResult((short)-425);
-            LOG.info("Exception in generating GetFromStore response: " + e.getMessage());
+            LOG.warning("Exception in generating GetFromStore response: " + e.getMessage());
         }
         return resp;
     }

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -137,7 +137,12 @@ public class StoreImpl implements IStore {
     }
 
     @Override
-    public WMLS_GetFromStoreResponse getFromStore(String WMLtypeIn, String QueryIn, String OptionsIn, String CapabilitiesIn) {
+    public WMLS_GetFromStoreResponse getFromStore(
+        String WMLtypeIn, 
+        String QueryIn, 
+        String OptionsIn, 
+        String CapabilitiesIn
+    ) {
         LOG.info("Executing GetFromStore");
         WMLS_GetFromStoreResponse resp = new WMLS_GetFromStoreResponse();
         resp.setSuppMsgOut("");

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -16,7 +16,7 @@
 package com.hashmapinc.tempus.witsml.server.api;
 
 import com.hashmapinc.tempus.witsml.server.WitsmlApiConfig;
-import com.hashmapinc.tempus.witsml.server.api.QueryContext;
+import com.hashmapinc.tempus.witsml.QueryContext;
 import com.hashmapinc.tempus.witsml.server.api.model.WMLS_GetCapResponse;
 import com.hashmapinc.tempus.witsml.server.api.model.WMLS_GetFromStoreResponse;
 import com.hashmapinc.tempus.witsml.server.api.model.cap.ServerCap;
@@ -25,6 +25,7 @@ import com.hashmapinc.tempus.witsml.WitsmlUtil;
 import com.hashmapinc.tempus.witsml.WitsmlObjectParser;
 import com.hashmapinc.tempus.witsml.valve.AbstractValve;
 import com.hashmapinc.tempus.witsml.valve.ValveFactory;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -32,6 +33,7 @@ import org.springframework.stereotype.Service;
 import javax.jws.WebService;
 import java.util.logging.Logger;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @WebService(serviceName = "StoreSoapBinding", portName = "StoreSoapBindingSoap",
@@ -137,15 +139,16 @@ public class StoreImpl implements IStore {
         try {
             // construct query context
             String clientVersion = WitsmlUtil.getVersionFromXML(QueryIn);
+            Map<String,String> optionsMap = WitsmlUtil.parseOptionsIn(OptionsIn);
             QueryContext qc = new QueryContext(
                 clientVersion,
                 WMLtypeIn,
-                OptionsIn,
+                optionsMap,
                 QueryIn
             );
 
             // execute query
-            AbstractValve valve = ValveFactory.buildValve("DoT"); //TODO: don't hard code this, don't access locally (need a class field for this)
+            AbstractValve valve = ValveFactory.buildValve("DoT"); // TODO: don't hard code this, don't access locally (need a class field for this)
 
             // populate response
             resp.setSuppMsgOut("");

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
-  Copyright © 2018-2018 Hashmap, Inc
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
- */
 package com.hashmapinc.tempus.witsml.server.api;
 
 import com.hashmapinc.tempus.witsml.server.WitsmlApiConfig;

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/QueryContext.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/QueryContext.java
@@ -13,11 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hashmapinc.tempus.witsml.server.api;
+package com.hashmapinc.tempus.witsml;
 
 import java.util.Map;
-
-import com.hashmapinc.tempus.witsml.WitsmlUtil;
 
 /**
  * QueryContext is used to hold the state of an individual query
@@ -33,19 +31,19 @@ public class QueryContext {
      * 
      * @param clientVersion - the WITSML version used by the client that sent the query
      * @param objectType - the type of WITSML object being queried for
-     * @param optionsIn - String holding the options in for the query per the WITSML 1.3/1.4 specs
+     * @param optionsIn - MAP of options_in key/value pairs
      * @param queryXML - String holding the raw xml query sent from the client
      */
     public QueryContext(
         String clientVersion,
         String objectType,
-        String optionsIn,
+        Map<String, String> optionsIn,
         String queryXML
     ) {
         // instantiate values
         this.CLIENT_VERSION = clientVersion;
         this.OBJECT_TYPE = objectType;
-        this.OPTIONS_IN = WitsmlUtil.parseOptionsIn(optionsIn); // parse this in the constructor to ensure it is immutable
+        this.OPTIONS_IN = optionsIn;
         this.QUERY_XML = queryXML; 
     }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/AbstractValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/AbstractValve.java
@@ -19,6 +19,7 @@ import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.witsml.valve.AbstractTranslator;
 import com.hashmapinc.tempus.witsml.valve.AbstractDelegator;
 import com.hashmapinc.tempus.witsml.valve.AbstractAuth;
+import com.hashmapinc.tempus.witsml.QueryContext;
 
 import java.util.Map;
 
@@ -41,11 +42,10 @@ public abstract class AbstractValve {
 
     /**
      * Gets the object based on the query from the WITSML STORE API
-     * @param query POJO representing the query that was received
-     * @param options The options that were received as part of the query
+     * @param qc - QueryContext needed to execute the getObject querying
      * @return The resultant object from the query
      */
-    public abstract AbstractWitsmlObject getObject(AbstractWitsmlObject query, Map<String, String> options);
+    public abstract AbstractWitsmlObject getObject(QueryContext qc);
 
     /**
      * Creates an object

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -18,6 +18,7 @@ package com.hashmapinc.tempus.witsml.valve.dot;
 import java.util.Map;
 
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
+import com.hashmapinc.tempus.witsml.QueryContext;
 import com.hashmapinc.tempus.witsml.valve.AbstractValve;
 import com.hashmapinc.tempus.witsml.valve.AbstractDelegator;
 import com.hashmapinc.tempus.witsml.valve.AbstractTranslator;
@@ -59,12 +60,12 @@ public class DotValve extends AbstractValve {
 
     /**
      * Gets the object based on the query from the WITSML STORE API
-     * @param query POJO representing the query that was received
-     * @param options The options that were received as part of the query
+     * 
+     * @param qc - QueryContext needed to execute the getObject querying
      * @return The resultant object from the query
      */
     @Override
-    public AbstractWitsmlObject getObject(AbstractWitsmlObject query, Map<String, String> options) {
+    public AbstractWitsmlObject getObject(QueryContext qc) {
         return null;
     }
 

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/mock/MockValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/mock/MockValve.java
@@ -18,6 +18,7 @@ package com.hashmapinc.tempus.witsml.valve.mock;
 import java.util.Map;
 
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
+import com.hashmapinc.tempus.witsml.QueryContext;
 import com.hashmapinc.tempus.witsml.valve.AbstractValve;
 import com.hashmapinc.tempus.witsml.valve.AbstractDelegator;
 import com.hashmapinc.tempus.witsml.valve.AbstractTranslator;
@@ -60,12 +61,12 @@ public class MockValve extends AbstractValve {
 
     /**
      * Gets the object based on the query from the WITSML STORE API
-     * @param query POJO representing the query that was received
-     * @param options The options that were received as part of the query
+     * 
+     * @param qc      - QueryContext needed to execute the getObject querying
      * @return The resultant object from the query
      */
     @Override
-    public AbstractWitsmlObject getObject(AbstractWitsmlObject query, Map<String, String> options) {
+    public AbstractWitsmlObject getObject(QueryContext qc) {
         return null;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,8 +129,8 @@
 	</build>
 
 	<modules>
-        <module>df-server</module>
         <module>df-valve</module>
+        <module>df-server</module>
 	</modules>
 
     <repositories>


### PR DESCRIPTION
This PR includes:
- creation of the `QueryContext` class in the `df-valve` for shuttling query information from `df-server` to `df-valve`.
- fixes to the project pom structure to allow `df-server` to import `df-valve` classes.
- restructured the `AbstractValve` definition of `getFromStore` to accept a `QueryContext` object. The `Mock` and `DoT` valve implementations were updated as well.
- logic at the `getFromStore` handler to create a hardcoded `DoT` valve, create a `QueryContext`, and to call the `getFromStore` valve handler

This connects to #89 