### PR TITLE
This commit resolves #110 and resolves #208 and #90 by adding a custo…

### DIFF
--- a/df-server/pom.xml
+++ b/df-server/pom.xml
@@ -54,61 +54,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-spring-boot-starter-jaxws</artifactId>
-            <version>3.2.6</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.2.6</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.2.6</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.ws</groupId>
-            <artifactId>jaxws-rt</artifactId>
-            <version>2.3.1</version>
-            <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- used for witsml object ser/de -->
         <dependency>

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/WitsmlApiConfig.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/WitsmlApiConfig.java
@@ -39,12 +39,12 @@ public class WitsmlApiConfig {
     }
 
     @Autowired
-    private void getBus(Bus bus){
+    private void setBus(Bus bus){
         this.bus = bus;
     }
 
     @Autowired
-    private void getStoreImpl(StoreImpl storeImpl){
+    private void setStoreImpl(StoreImpl storeImpl){
         this.storeImpl = storeImpl;
     }
 

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/WitsmlServerApplication.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/WitsmlServerApplication.java
@@ -17,8 +17,10 @@ package com.hashmapinc.tempus.witsml.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
 
-@SpringBootApplication
+@SpringBootApplication()
 public class WitsmlServerApplication {
 
 	public static void main(String[] args) {

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/WitsmlServerApplication.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/WitsmlServerApplication.java
@@ -17,8 +17,6 @@ package com.hashmapinc.tempus.witsml.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication()
 public class WitsmlServerApplication {

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/AuthConfig.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/AuthConfig.java
@@ -16,22 +16,21 @@
 package com.hashmapinc.tempus.witsml.server.api;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
 
 @Configuration
 @EnableWebSecurity
-@ComponentScan
 public class AuthConfig extends WebSecurityConfigurerAdapter {
 
     private ValveAuthenticationProvider valveAuthenticationProvider;
 
     @Autowired
-    public ValveAuthenticationProvider getValveAuthenticationProvider() {
-        return valveAuthenticationProvider;
+    public void setValveAuthenticationProvider(ValveAuthenticationProvider valveAuthenticationProvider) {
+        this.valveAuthenticationProvider = valveAuthenticationProvider;
     }
 
     @Override
@@ -43,6 +42,10 @@ public class AuthConfig extends WebSecurityConfigurerAdapter {
                 .anyRequest()
                 .permitAll()
                 .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authenticationProvider(valveAuthenticationProvider)
                 .httpBasic()
                 .and()
                 .anonymous()

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/AuthConfig.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/AuthConfig.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright © 2018-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hashmapinc.tempus.witsml.server.api;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+@EnableWebSecurity
+@ComponentScan
+public class AuthConfig extends WebSecurityConfigurerAdapter {
+
+    private ValveAuthenticationProvider valveAuthenticationProvider;
+
+    @Autowired
+    public ValveAuthenticationProvider getValveAuthenticationProvider() {
+        return valveAuthenticationProvider;
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf()
+                .disable()
+                .authorizeRequests()
+                .anyRequest()
+                .permitAll()
+                .and()
+                .httpBasic()
+                .and()
+                .anonymous()
+                .disable();
+    }
+}

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -27,7 +27,6 @@ import com.hashmapinc.tempus.witsml.valve.IValve;
 import com.hashmapinc.tempus.witsml.valve.ValveFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
@@ -40,7 +39,6 @@ import java.util.logging.Logger;
 @WebService(serviceName = "StoreSoapBinding", portName = "StoreSoapBindingSoap",
         targetNamespace = "http://www.witsml.org/wsdl/120",
         endpointInterface = "com.hashmapinc.tempus.witsml.server.api.IStore")
-@EnableConfigurationProperties
 public class StoreImpl implements IStore {
 
     private static final Logger LOG = Logger.getLogger(StoreImpl.class.getName());

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -15,31 +15,26 @@
  */
 package com.hashmapinc.tempus.witsml.server.api;
 
-import com.hashmapinc.tempus.witsml.server.WitsmlApiConfig;
+import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.witsml.QueryContext;
+import com.hashmapinc.tempus.witsml.WitsmlObjectParser;
+import com.hashmapinc.tempus.witsml.WitsmlUtil;
+import com.hashmapinc.tempus.witsml.server.WitsmlApiConfig;
 import com.hashmapinc.tempus.witsml.server.api.model.WMLS_GetCapResponse;
 import com.hashmapinc.tempus.witsml.server.api.model.WMLS_GetFromStoreResponse;
 import com.hashmapinc.tempus.witsml.server.api.model.cap.ServerCap;
-import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
-import com.hashmapinc.tempus.witsml.WitsmlUtil;
-import com.hashmapinc.tempus.witsml.WitsmlObjectParser;
 import com.hashmapinc.tempus.witsml.valve.IValve;
 import com.hashmapinc.tempus.witsml.valve.ValveFactory;
-
-import org.apache.catalina.Store;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
-import javax.annotation.Resource;
 import javax.jws.WebService;
-import java.util.logging.Logger;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 @Service
 @WebService(serviceName = "StoreSoapBinding", portName = "StoreSoapBindingSoap",

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -28,6 +28,7 @@ import com.hashmapinc.tempus.witsml.valve.ValveFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Service;
 
 import javax.jws.WebService;
@@ -45,6 +46,7 @@ public class StoreImpl implements IStore {
 
     private ServerCap cap;
     private WitsmlApiConfig witsmlApiConfigUtil;
+    private IValve valve;
 
     @Autowired
     private void setServerCap(ServerCap cap){

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -28,7 +28,6 @@ import com.hashmapinc.tempus.witsml.valve.ValveFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Service;
 
 import javax.jws.WebService;
@@ -46,7 +45,6 @@ public class StoreImpl implements IStore {
 
     private ServerCap cap;
     private WitsmlApiConfig witsmlApiConfigUtil;
-    private IValve valve;
 
     @Autowired
     private void setServerCap(ServerCap cap){

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -45,21 +45,19 @@ public class StoreImpl implements IStore {
 
     private ServerCap cap;
     private WitsmlApiConfig witsmlApiConfigUtil;
+    private IValve valve;
+    @Value("${valve.name}")
+    private String valveName;
 
     @Autowired
     private void setServerCap(ServerCap cap){
         this.cap = cap;
     }
 
-    @Value("${valve.name}")
-    private String valveName;
-
     @Autowired
     private void setWitsmlApiConfig(WitsmlApiConfig witsmlApiConfigUtil){
         this.witsmlApiConfigUtil = witsmlApiConfigUtil;
     }
-
-    private IValve valve;
 
     @Value("${wmls.version:7}")
     private String version;

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/ValveAuthenticationProvider.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/ValveAuthenticationProvider.java
@@ -16,7 +16,8 @@
 package com.hashmapinc.tempus.witsml.server.api;
 
 import com.hashmapinc.tempus.witsml.valve.IValve;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.hashmapinc.tempus.witsml.valve.ValveFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -25,6 +26,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 
 @Component
@@ -32,12 +34,14 @@ import java.util.ArrayList;
 public class ValveAuthenticationProvider implements AuthenticationProvider {
 
     private IValve valve;
+    @Value("${valve.name}")
+    private String valveName;
 
-    @Autowired
-    public void setValve(IValve valve){
-        this.valve = valve;
+    @PostConstruct
+    private void setValve(){
+        valve = ValveFactory.buildValve(valveName);
     }
-
+    
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
 

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/ValveAuthenticationProvider.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/ValveAuthenticationProvider.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright © 2018-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hashmapinc.tempus.witsml.server.api;
+
+import com.hashmapinc.tempus.witsml.valve.IValve;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+
+@Component
+@ComponentScan(basePackages = "com.hashmapinc.tempus.witsml.valve")
+public class ValveAuthenticationProvider implements AuthenticationProvider {
+
+    private IValve valve;
+
+    @Autowired
+    public void setValve(IValve valve){
+        this.valve = valve;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+
+        String name = authentication.getName();
+        UsernamePasswordAuthenticationToken account = (UsernamePasswordAuthenticationToken)authentication;
+        String password = (String)account.getCredentials();
+
+        boolean authResult = valve.authenticate(name,password);
+
+        if (!authResult)
+            throw new BadCredentialsException("Bad credentials for user");
+
+        UsernamePasswordAuthenticationToken auth;
+        auth = new UsernamePasswordAuthenticationToken(name, password,new ArrayList<>());
+
+        return auth;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+}

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/ValveAuthenticationProvider.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/ValveAuthenticationProvider.java
@@ -17,7 +17,6 @@ package com.hashmapinc.tempus.witsml.server.api;
 
 import com.hashmapinc.tempus.witsml.valve.IValve;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;

--- a/df-server/src/main/resources/application.properties
+++ b/df-server/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 cxf.path=/Service
 server.port=7070
 wmls.version=1.3.1.1,1.4.1.1
-valve.class=ValveDoT
+valve.name=DoT

--- a/df-server/src/main/resources/application.properties
+++ b/df-server/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 cxf.path=/Service
 server.port=7070
 wmls.version=1.3.1.1,1.4.1.1
+valve.class=ValveDoT

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
@@ -56,4 +56,6 @@ public interface IValve {
      * @param query POJO representing the object that was received
      */
     public void updateObject(AbstractWitsmlObject query);
+
+    public boolean authenticate(String userName, String password);
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -22,7 +22,7 @@ import com.hashmapinc.tempus.witsml.valve.IValve;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import org.springframework.stereotype.Component;
 
-@Component(value = "valveDoT")
+@Component(value = "valveDot")
 public class DotValve implements IValve {
     final String NAME = "DoT"; // DoT = Drillops Town
     final String DESCRIPTION = "Valve for interaction with Drillops Town"; // DoT = Drillops Town

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -15,10 +15,14 @@
  */
 package com.hashmapinc.tempus.witsml.valve.dot;
 
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.witsml.QueryContext;
 import com.hashmapinc.tempus.witsml.valve.IValve;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import org.springframework.stereotype.Component;
 
+@Component(value = "valveDoT")
 public class DotValve implements IValve {
     final String NAME = "DoT"; // DoT = Drillops Town
     final String DESCRIPTION = "Valve for interaction with Drillops Town"; // DoT = Drillops Town
@@ -28,9 +32,8 @@ public class DotValve implements IValve {
 
     public DotValve() {
         this.delegator = new DotDelegator();
-        this.translator = new DotTranslator();
-        //please provide the authentication API here.
-        this.auth = new DotAuth("http://witsml-qa.hashmapinc.com:8080/");
+        this.translator = new DotTranslator();//please provide the authentication API here.
+        this.auth = new DotAuth("http://localhost:8080/");
     }
 
     /**
@@ -87,5 +90,25 @@ public class DotValve implements IValve {
      */
     @Override
     public void updateObject(AbstractWitsmlObject query) {
+    }
+
+    /**
+     * Authenticates with the DotAuth class to get a JWT
+     * @param userName The user name to authenticate with
+     * @param password The password to authenticate with
+     * @return True if successful, false if not
+     */
+    //TODO: This should throw an exception not be a boolean value so that a descriptive message can be logged/returned
+    @Override
+    public boolean authenticate(String userName, String password) {
+        try {
+            //TODO: Remove the hardcoded apiKey
+            DecodedJWT jwt = auth.getJWT("test", userName, password);
+            return jwt != null;
+
+        } catch (UnirestException e) {
+            return false;
+        }
+
     }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -20,9 +20,7 @@ import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.witsml.QueryContext;
 import com.hashmapinc.tempus.witsml.valve.IValve;
 import com.mashape.unirest.http.exceptions.UnirestException;
-import org.springframework.stereotype.Component;
 
-@Component(value = "valveDot")
 public class DotValve implements IValve {
     final String NAME = "DoT"; // DoT = Drillops Town
     final String DESCRIPTION = "Valve for interaction with Drillops Town"; // DoT = Drillops Town

--- a/pom.xml
+++ b/pom.xml
@@ -152,11 +152,7 @@
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-spring-boot-starter-jaxws</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,68 @@
 		</plugins>
 	</build>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-spring-boot-starter-jaxws</artifactId>
+			<version>3.2.6</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<version>1.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-frontend-jaxws</artifactId>
+			<version>3.2.6</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-transports-http</artifactId>
+			<version>3.2.6</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.ws</groupId>
+			<artifactId>jaxws-rt</artifactId>
+			<version>2.3.1</version>
+			<type>pom</type>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
 	<modules>
         <module>df-valve</module>
         <module>df-server</module>


### PR DESCRIPTION
This commit resolves #110 and resolves #108 and resolves #90 by adding a custom authentication provider to df-server, adding an authorization method to IValve, and autowiring the ivalve to the authentication provider. The IValve still needs to be autowired to store impl and there are ToDos that have been marked in the dot valve. Additionally the auth module of the DoT valve crashes with a 500 on invalid credentals. This will be tracked as a part of #112.