### PR TITLE
df-131 -> added Valve support for getCap

### DIFF
--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/model/cap/ServerCap.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/model/cap/ServerCap.java
@@ -318,7 +318,7 @@ public class ServerCap {
 
             // Add function to list
             function.add(localFunction);
-            it.remove();
+            //it.remove();
         }
 
         // Add server to plural element

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
@@ -15,6 +15,9 @@
  */
 package com.hashmapinc.tempus.witsml.valve;
 
+import java.util.Map;
+import java.util.List;
+
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.witsml.QueryContext;
 
@@ -59,10 +62,18 @@ public interface IValve {
     public void updateObject(AbstractWitsmlObject query);
 
     /**
+     * Performs authentication
      * 
      * @param userName - basic auth username for authentication
      * @param password - basic auth password for authentication
      * @return status - boolean value; true = success, false = failure
      */
     public boolean authenticate(String userName, String password);
+
+    /**
+     * Return a map of FUNCTION_NAME->ARRAY_OF_SUPPORTED_OBJECTS
+     * 
+     * @return capabilities - map of FUNCTION_NAME->ARRAY_OF_SUPPORTED_OBJECTS
+     */
+    public Map<String, AbstractWitsmlObject[]> getCap();
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
@@ -58,5 +58,11 @@ public interface IValve {
      */
     public void updateObject(AbstractWitsmlObject query);
 
+    /**
+     * 
+     * @param userName - basic auth username for authentication
+     * @param password - basic auth password for authentication
+     * @return status - boolean value; true = success, false = failure
+     */
     public boolean authenticate(String userName, String password);
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -82,6 +82,7 @@ public class DotValve implements IValve {
      */
     @Override
     public String createObject(QueryContext qc) {
+        // TODO: move this to a delegator and check types!!!!!
         // get a 1.4.1.1 json string
         AbstractWitsmlObject obj = qc.WITSML_OBJECTS.get(0); // TODO: don't assume 1 object
         String objectJSON = this.TRANSLATOR.get1411JSONString(obj);

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -26,6 +26,7 @@ import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class DotValve implements IValve {
@@ -146,6 +147,33 @@ public class DotValve implements IValve {
         } catch (UnirestException e) {
             return false;
         }
+    }
 
+    /**
+     * Return a map of FUNCTION_NAME->LIST_OF_SUPPORTED_OBJECTS
+     * 
+     * @return capabilities - map of FUNCTION_NAME->LIST_OF_SUPPORTED_OBJECTS
+     */
+    public Map<String, AbstractWitsmlObject[]> getCap() {
+        // define capabilities map
+        Map<String, AbstractWitsmlObject[]> cap = new HashMap<>(); 
+
+        // array of supported functions
+        String[] funcs = {
+            "AddToStore"
+        }; 
+
+        // supported objects for each function
+        AbstractWitsmlObject well = new com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWell(); // 1311 is arbitrary
+        AbstractWitsmlObject[][] supportedObjects = {
+            {well} // ADD TO STORE OBJECTS
+        };
+
+        // populate cap
+        for (int i = 0; i < funcs.length; i++) {
+            cap.put(funcs[i], supportedObjects[i]);
+        }
+
+        return cap;
     }
 }


### PR DESCRIPTION
This PR includes:
- addition of `getCap` to `IValve` to get capabilities directly from a valve
- implementation of `getCap` in `DotValve`
- logic in autowired `valve` constructor in `StoreImpl` that pulls valve-specific functionality directly from the `valve` in to the `cap` field.

This connects to #131 