### PR TITLE
df-126 -> DELETE support for DoTValve WELL

### DIFF
--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/IStore.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/IStore.java
@@ -18,6 +18,7 @@ package com.hashmapinc.tempus.witsml.server.api;
 import com.hashmapinc.tempus.witsml.server.api.model.WMLS_AddToStoreResponse;
 import com.hashmapinc.tempus.witsml.server.api.model.WMLS_GetCapResponse;
 import com.hashmapinc.tempus.witsml.server.api.model.WMLS_GetFromStoreResponse;
+import com.hashmapinc.tempus.witsml.server.api.model.WMLS_DeleteFromStoreResponse;
 import com.hashmapinc.tempus.witsml.server.api.model.WMLS_GetVersionResponse;
 
 import javax.jws.WebMethod;
@@ -44,7 +45,7 @@ public interface IStore {
     @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_DeleteFromStore", operationName = "WMLS_DeleteFromStore")
     @RequestWrapper(targetNamespace = "http://www.witsml.org/message/120")
     @SOAPBinding(style=SOAPBinding.Style.RPC, parameterStyle=SOAPBinding.ParameterStyle.BARE, use=SOAPBinding.Use.ENCODED)
-    String deleteFromStore(
+    WMLS_DeleteFromStoreResponse deleteFromStore(
             @WebParam(partName = "WMLtypeIn") String WMLtypeIn,
             @WebParam(partName = "QueryIn") String QueryIn,
             @WebParam(partName = "OptionsIn") String OptionsIn,

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/IStore.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/IStore.java
@@ -41,6 +41,16 @@ public interface IStore {
         @WebParam(partName = "CapabilitiesIn") String CapabilitiesIn
     );
 
+    @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_DeleteFromStore", operationName = "WMLS_DeleteFromStore")
+    @RequestWrapper(targetNamespace = "http://www.witsml.org/message/120")
+    @SOAPBinding(style=SOAPBinding.Style.RPC, parameterStyle=SOAPBinding.ParameterStyle.BARE, use=SOAPBinding.Use.ENCODED)
+    String deleteFromStore(
+            @WebParam(partName = "WMLtypeIn") String WMLtypeIn,
+            @WebParam(partName = "QueryIn") String QueryIn,
+            @WebParam(partName = "OptionsIn") String OptionsIn,
+            @WebParam(partName = "CapabilitiesIn") String CapabilitiesIn
+    );
+
     @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_GetVersion", operationName = "WMLS_GetVersion")
     @ResponseWrapper(className = "com.hashmapinc.tempus.witsml.server.api.model.WMLS_GetVersionResponse")
     @SOAPBinding(style = SOAPBinding.Style.RPC, parameterStyle= SOAPBinding.ParameterStyle.BARE, use = SOAPBinding.Use.ENCODED)

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -152,6 +152,16 @@ public class StoreImpl implements IStore {
     }
 
     @Override
+    public String deleteFromStore(
+        String WMLtypeIn,
+        String QueryIn,
+        String OptionsIn,
+        String CapabilitiesIn
+    ) {
+        return "RANDY IS A COOL GUY";
+    }
+
+    @Override
     public WMLS_GetVersionResponse getVersion() {
         LOG.info("Executing GetVersion");
         WMLS_GetVersionResponse resp = new WMLS_GetVersionResponse();

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -30,7 +30,6 @@ import com.hashmapinc.tempus.witsml.server.api.model.cap.ServerCap;
 import com.hashmapinc.tempus.witsml.valve.IValve;
 import com.hashmapinc.tempus.witsml.valve.ValveException;
 import com.hashmapinc.tempus.witsml.valve.ValveFactory;
-import org.apache.catalina.Valve;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -28,6 +28,7 @@ import com.hashmapinc.tempus.witsml.server.api.model.WMLS_DeleteFromStoreRespons
 import com.hashmapinc.tempus.witsml.server.api.model.cap.DataObject;
 import com.hashmapinc.tempus.witsml.server.api.model.cap.ServerCap;
 import com.hashmapinc.tempus.witsml.valve.IValve;
+import com.hashmapinc.tempus.witsml.valve.ValveException;
 import com.hashmapinc.tempus.witsml.valve.ValveFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -300,6 +301,11 @@ public class StoreImpl implements IStore {
                 resp.setSuppMsgOut("Error from REST backend");
                 resp.setResult((short) -1);
             }
+        } catch (ValveException ve) {
+            resp.setResult((short)-425);
+            LOG.warning("Valve Exception in GetFromStore: " + ve.getMessage());
+            resp.setSuppMsgOut("Error: " + ve.getMessage());
+            ve.printStackTrace();
         } catch (Exception e) {
             resp.setResult((short)-425);
             LOG.warning("Exception in generating GetFromStore response: " + e.toString());

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -183,7 +183,19 @@ public class StoreImpl implements IStore {
 
         // try to delete
         try {
-            this.valve.deleteObject(witsmlObjects);
+            // construct query context
+            Map<String,String> optionsMap = WitsmlUtil.parseOptionsIn(OptionsIn);
+            ValveUser user = (ValveUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+            QueryContext qc = new QueryContext(
+                    null, // client version not needed
+                    WMLtypeIn,
+                    optionsMap,
+                    QueryIn,
+                    witsmlObjects,
+                    user.getUserName(),
+                    user.getPassword()
+            );
+            this.valve.deleteObject(qc);
             resp.setResult((short) 1);
         } catch (Exception e) {
             resp.setSuppMsgOut("Error: " + e.getMessage());

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/model/WMLS_DeleteFromStoreResponse.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/model/WMLS_DeleteFromStoreResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright © 2018-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hashmapinc.tempus.witsml.server.api.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name="WMLS_DeleteFromStoreResponse")
+public class WMLS_DeleteFromStoreResponse {
+    private Short Result;
+    private String SuppMsgOut;
+
+    public Short getResult() {
+        return Result;
+    }
+
+    public void setResult(Short result) {
+        Result = result;
+    }
+
+    public String getSuppMsgOut() {
+        return SuppMsgOut;
+    }
+
+    public void setSuppMsgOut(String suppMsgOut) {
+        SuppMsgOut = suppMsgOut;
+    }
+}

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
@@ -39,7 +39,7 @@ public interface IValve {
      * @param qc - QueryContext needed to execute the getObject querying
      * @return The resultant object from the query in XML string format
      */
-    public String getObject(QueryContext qc);
+    public String getObject(QueryContext qc) throws ValveException;
 
     /**
      * Creates an object
@@ -47,7 +47,7 @@ public interface IValve {
      * @param qc - QueryContext needed to execute the createObject querying
      * @return the UID of the newly created object
      */
-    public String createObject(QueryContext qc);
+    public String createObject(QueryContext qc) throws ValveException;
 
     /**
      * Deletes an object

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
@@ -51,15 +51,15 @@ public interface IValve {
 
     /**
      * Deletes an object
-     * @param query POJO representing the object that was received
+     * @param witsmlObjects - list of AbstractWitsmlObjects to delete
      */
-    public void deleteObject(AbstractWitsmlObject query);
+    public void deleteObject(List<AbstractWitsmlObject> witsmlObjects) throws ValveException;
 
     /**
      * Updates an already existing object
-     * @param query POJO representing the object that was received
+     * @param witsmlObjects - list of AbstractWitsmlObjects to update
      */
-    public void updateObject(AbstractWitsmlObject query);
+    public void updateObject(List<AbstractWitsmlObject> witsmlObjects);
 
     /**
      * Performs authentication

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
@@ -51,9 +51,9 @@ public interface IValve {
 
     /**
      * Deletes an object
-     * @param witsmlObjects - list of AbstractWitsmlObjects to delete
+     * @param qc - QueryContext needed to execute the deleteObject querying
      */
-    public void deleteObject(List<AbstractWitsmlObject> witsmlObjects) throws ValveException;
+    public void deleteObject(QueryContext qc) throws ValveException;
 
     /**
      * Updates an already existing object

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/ValveException.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/ValveException.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright © 2018-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hashmapinc.tempus.witsml.valve;
+
+/**
+ * Catch-all exception for any valve exception.
+ *
+ * "Only you can prevent bad exception messages!"
+ */
+public class ValveException extends Exception {
+    public ValveException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -53,7 +53,7 @@ public class DotDelegator {
         // construct the endpoint for each object type
         switch (objectType) { // TODO: add support for wellbore, log, and trajectory
             case "well":
-                endpoint = this.URL + "witsml/wells/" + uid;
+                endpoint = this.URL + "/witsml/wells/" + uid;
                 break;
             default:
                 throw new ValveException("Unsupported object type<" + objectType + "> for DELETE");
@@ -87,26 +87,28 @@ public class DotDelegator {
      */
     public String addWellToStore(String objectJSON, String tokenString) {
         // create endpoint
-        String endpoint = this.URL + "witsml/wells/";
+        String endpoint = this.URL + "/witsml/wells/";
 
         // send post
         try {
-            HttpResponse<JsonNode> response = Unirest
+            HttpResponse<String> response = Unirest
                 .post(endpoint)
                 .header("accept", "application/json")
                 .header("Authorization", tokenString)
                 .header("Ocp-Apim-Subscription-Key", this.API_KEY)
                 .body(objectJSON)
-                .asJson();
+                .asString();
 
             int status = response.getStatus();
 
             if (201 == status || 200 == status) {
-                String uid = response.getBody().getObject().getString("uid");
-                LOG.info("Successfully put well object with uid=" + uid);
+                JsonNode body = new JsonNode(response.getBody());
+                String uid = body.getObject().getString("uid");
+                LOG.info("Successfully posted well object with uid=" + uid);
                 return uid;
             } else {
                 LOG.warning("Received status code from Well POST: " + status);
+                LOG.warning("POST response: " + response.getBody());
                 return null;
             }
         } catch (Exception e) {
@@ -126,7 +128,7 @@ public class DotDelegator {
      */
     public String addWellboreToStore(String objectJSON, String tokenString) {
         // create endpoint
-        String endpoint = this.URL + "witsml/wellbores/";
+        String endpoint = this.URL + "/witsml/wellbores/";
 
         // send post
         try {

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -60,12 +60,12 @@ public class DotDelegator {
         }
 
         // make the DELETE call.
-        HttpResponse<JsonNode> response = Unirest
+        HttpResponse<String> response = Unirest
             .delete(endpoint)
             .header("accept", "application/json")
             .header("Authorization", tokenString)
             .header("Ocp-Apim-Subscription-Key", this.API_KEY)
-            .asJson();
+            .asString();
 
         // check response status
         int status = response.getStatus();
@@ -73,6 +73,7 @@ public class DotDelegator {
             LOG.info("Received successful status code from DoT DELETE call: " + status);
         } else {
             LOG.warning("Received failure status code from DoT DELETE: " + status);
+            LOG.warning("DELETE response: " + response.getBody());
             throw new ValveException("DELETE DoT REST call failed with status code: " + status);
         }
     }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -161,12 +161,30 @@ public class DotValve implements IValve {
 
     /**
      * Deletes an object
-     * @param witsmlObjects - list of AbstractWitsmlObjects to delete
+     * @param qc - QueryContext with information needed to delete object
      */
     @Override
     public void deleteObject(
-            List<AbstractWitsmlObject> witsmlObjects
+            QueryContext qc
     ) throws ValveException {
+        // get auth token
+        String tokenString;
+        try {
+            tokenString = this.AUTH.getJWT(qc.USERNAME, qc.PASSWORD).getToken();
+        } catch (Exception e) {
+            LOG.warning("Exception in deleteObject while authenticating: " + e.getMessage());
+            throw new ValveException(e.getMessage());
+        }
+
+        // delete each object
+        try {
+            for (AbstractWitsmlObject witsmlObject : qc.WITSML_OBJECTS)
+                this.DELEGATOR.deleteObject(witsmlObject, tokenString);
+        } catch (UnirestException ue) {
+            LOG.warning("Got UnirestException in DotValve delete object: " + ue.getMessage());
+            throw new ValveException("Delete error: " + ue.getMessage());
+        }
+
     }
 
     /**

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -117,12 +117,12 @@ public class DotValve implements IValve {
             } else {
                 LOG.warning("Received status code from GET object: " + status);
                 LOG.warning("GET response: " + response.getBody());
-                throw new ValveException("Valve error from DoT GET call: " + response.getBody());
+                throw new ValveException(response.getBody());
             }
         } catch (Exception e) {
             // TODO: handle exception
             LOG.warning("Error while getting object in DoTValve: " + e);
-            throw new ValveException("Error while getting object in DoTValve: " + e);
+            throw new ValveException(e.getMessage());
         }
     }
 
@@ -147,9 +147,7 @@ public class DotValve implements IValve {
         try {
             tokenString = this.AUTH.getJWT(qc.USERNAME, qc.PASSWORD).getToken();
         } catch (Exception e) {
-            LOG.warning("Received error getting token string for createObject: " + e);
-            e.printStackTrace();
-            return null;
+            throw new ValveException("Token error: " + e.getMessage());
         }
 
         // handle each supported object
@@ -159,8 +157,7 @@ public class DotValve implements IValve {
             case "wellbore":
                 return this.DELEGATOR.addWellboreToStore(objectJSON, tokenString);
             default:
-                LOG.warning("Unsupported type encountered in createObject. Type = <" + objectType + ">");
-                return null;
+                throw new ValveException("Unsupported type encountered in createObject. Type = <" + objectType + ">");
         }
     }
 

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -87,12 +87,12 @@ public class DotValve implements IValve {
 
         // send get
         try {
-            HttpResponse<JsonNode> response = Unirest
+            HttpResponse<String> response = Unirest
                 .get(endpoint)
                 .header("accept", "application/json")
                 .header("Authorization", this.AUTH.getJWT(qc.USERNAME, qc.PASSWORD).getToken())
                 .header("Ocp-Apim-Subscription-Key", this.API_KEY)
-                .asJson();
+                .asString();
             
             int status = response.getStatus();
 
@@ -101,7 +101,7 @@ public class DotValve implements IValve {
 
                 // get an abstractWitsmlObject from merging the query and the result JSON objects
                 JSONObject queryJSON = new JSONObject(obj.getJSONString("1.4.1.1"));
-                JSONObject responseJSON = response.getBody().getObject();
+                JSONObject responseJSON = new JsonNode(response.getBody()).getObject();
                 AbstractWitsmlObject mergedResponse = this.TRANSLATOR.translateQueryResponse(queryJSON, responseJSON);
 
                 // return the proper xml string for the client version
@@ -114,6 +114,7 @@ public class DotValve implements IValve {
                 }
             } else {
                 LOG.warning("Received status code from GET object: " + status);
+                LOG.warning("GET response: " + response.getBody());
                 return null;
             }
         } catch (Exception e) {

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -15,12 +15,14 @@
  */
 package com.hashmapinc.tempus.witsml.valve.dot;
 
+import java.util.List;
 import java.util.logging.Logger;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.witsml.QueryContext;
 import com.hashmapinc.tempus.witsml.valve.IValve;
+import com.hashmapinc.tempus.witsml.valve.ValveException;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
@@ -159,18 +161,20 @@ public class DotValve implements IValve {
 
     /**
      * Deletes an object
-     * @param query POJO representing the object that was received
+     * @param witsmlObjects - list of AbstractWitsmlObjects to delete
      */
     @Override
-    public void deleteObject(AbstractWitsmlObject query) {
+    public void deleteObject(
+            List<AbstractWitsmlObject> witsmlObjects
+    ) throws ValveException {
     }
 
     /**
      * Updates an already existing object
-     * @param query POJO representing the object that was received
+     * @param witsmlObjects - list of AbstractWitsmlObjects to update
      */
     @Override
-    public void updateObject(AbstractWitsmlObject query) {
+    public void updateObject(List<AbstractWitsmlObject> witsmlObjects) {
     }
 
     /**

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -76,7 +76,9 @@ public class DotValve implements IValve {
      * @return The resultant object from the query in xml string format
      */
     @Override
-    public String getObject(QueryContext qc) {
+    public String getObject(
+            QueryContext qc
+    ) throws ValveException {
         // get the object and uid
         AbstractWitsmlObject obj = qc.WITSML_OBJECTS.get(0); //TODO: do not assume only one object
         LOG.info("Getting object from store: " + obj.toString());
@@ -110,17 +112,17 @@ public class DotValve implements IValve {
                 } else if ("1.3.1.1".equals(qc.CLIENT_VERSION)) {
                     return this.TRANSLATOR.get1311XMLString(mergedResponse); // version translation required
                 } else {
-                    return null;
+                    throw new ValveException("Unsupported client version: " + qc.CLIENT_VERSION);
                 }
             } else {
                 LOG.warning("Received status code from GET object: " + status);
                 LOG.warning("GET response: " + response.getBody());
-                return null;
+                throw new ValveException("Valve error from DoT GET call: " + response.getBody());
             }
         } catch (Exception e) {
             // TODO: handle exception
             LOG.warning("Error while getting object in DoTValve: " + e);
-            return null;
+            throw new ValveException("Error while getting object in DoTValve: " + e);
         }
     }
 
@@ -131,7 +133,9 @@ public class DotValve implements IValve {
      * @return the UID of the newly created object
      */
     @Override
-    public String createObject(QueryContext qc) {
+    public String createObject(
+            QueryContext qc
+    ) throws ValveException {
         // get object information
         AbstractWitsmlObject obj = qc.WITSML_OBJECTS.get(0); // TODO: don't assume 1 object
         LOG.info("Creating object: " + obj.toString());

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -195,6 +195,7 @@ public class DotValve implements IValve {
      */
     @Override
     public void updateObject(List<AbstractWitsmlObject> witsmlObjects) {
+        LOG.info("Updating witsml objects" + witsmlObjects.toString());
     }
 
     /**

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -202,7 +202,8 @@ public class DotValve implements IValve {
         // array of supported functions
         String[] funcs = {
             "AddToStore",
-            "GetFromStore"
+            "GetFromStore",
+            "DeleteFromStore",
         }; 
 
         // supported objects for each function
@@ -211,6 +212,7 @@ public class DotValve implements IValve {
         AbstractWitsmlObject[][] supportedObjects = {
             {well, wellbore}, // ADD TO STORE OBJECTS
             {well}, // GET FROM STORE OBJECTS
+            {well}, // DELETE FROM STORE OBJECTS
         };
 
         // populate cap

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -48,7 +48,7 @@ public class DotValveTest {
         this.well1311exists = false;
         this.well1411exists = false;
         HashMap<String, String> config = new HashMap<>();
-        config.put("baseurl", "http://localhost:8080/"); // TODO: MOCK THIS
+        config.put("baseurl", "http://witsml-qa.hashmapinc.com:8080/"); // TODO: MOCK THIS
         config.put("apikey", "COOLAPIKEY");
 		valve = new DotValve(config);
 	}

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -57,7 +57,7 @@ public class DotValveTest {
     // WELL
     //=========================================================================
 	@Test
-	public void createObjectWell1311() throws IOException, JAXBException{
+	public void createObjectWell1311() throws IOException, JAXBException, ValveException {
 	    // don't execute if the well exists. This is buggy in DoT right now
         if (this.well1311exists)
             return;
@@ -85,7 +85,7 @@ public class DotValveTest {
 	}
 
     @Test
-    public void createObjectWell1411() throws IOException, JAXBException{
+    public void createObjectWell1411() throws IOException, JAXBException, ValveException{
         // don't execute if the well exists. This is buggy in DoT right now
         if (this.well1411exists)
             return;
@@ -113,7 +113,7 @@ public class DotValveTest {
     }
 
     @Test
-    public void getObjectWell1311() throws IOException, JAXBException {
+    public void getObjectWell1311() throws IOException, JAXBException, ValveException {
         // add the object first
         this.createObjectWell1311();;
 
@@ -124,13 +124,12 @@ public class DotValveTest {
         QueryContext qc = new QueryContext("1.3.1.1", "well", null, well1311XML, witsmlObjects, this.username, this.password);
 
         // get
-        String xmlOut = this.valve.getObject(qc);
-        assertNotNull(xmlOut);
+        String xmlOut = this.valve.getObject(qc);assertNotNull(xmlOut);
         assertFalse(xmlOut.contains("ns0:wells"));
     }
 
     @Test
-    public void getObjectWell1411() throws IOException, JAXBException {
+    public void getObjectWell1411() throws IOException, JAXBException, ValveException {
         // add the object first
         this.createObjectWell1411();;
 
@@ -197,7 +196,7 @@ public class DotValveTest {
     // WELLBORE
     //=========================================================================
     @Test
-    public void createObjectWellbore1311() throws IOException, JAXBException {
+    public void createObjectWellbore1311() throws IOException, JAXBException, ValveException {
         // get query context
         String wellbore1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/wellbore1311.xml")));
         List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbores) WitsmlMarshal
@@ -212,7 +211,7 @@ public class DotValveTest {
     }
 
     @Test
-    public void createObjectWellbore1411() throws IOException, JAXBException {
+    public void createObjectWellbore1411() throws IOException, JAXBException, ValveException {
         // get query context
         String wellbore1411XML = new String(Files.readAllBytes(Paths.get("src/test/resources/wellbore1411.xml")));
         List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbores) WitsmlMarshal

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -38,15 +38,10 @@ public class DotValveTest {
 	private String username;
     private String password;
     private DotValve valve;
-    private boolean well1311exists; // indicates if the obj has been put yet
-    private boolean well1411exists; // indicates if the obj has been put yet
-
 	@Before
 	public void doSetup() {
 		this.username = "admin";
         this.password = "12345";
-        this.well1311exists = false;
-        this.well1411exists = false;
         HashMap<String, String> config = new HashMap<>();
         config.put("baseurl", "http://witsml-qa.hashmapinc.com:8080/"); // TODO: MOCK THIS
         config.put("apikey", "COOLAPIKEY");
@@ -58,58 +53,52 @@ public class DotValveTest {
     //=========================================================================
 	@Test
 	public void createObjectWell1311() throws IOException, JAXBException, ValveException {
-	    // don't execute if the well exists. This is buggy in DoT right now
-        if (this.well1311exists)
-            return;
+	    try {
+            // get query context
+            String well1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1311.xml")));
+            List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWells) WitsmlMarshal.deserialize(well1311XML, com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWell.class)).getWell();
+            QueryContext qc = new QueryContext(
+                    "1.3.1.1",
+                    "well",
+                    null,
+                    well1311XML,
+                    witsmlObjects,
+                    this.username,
+                    this.password
+            );
 
-        // get query context
-        String well1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1311.xml")));
-        List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>)((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWells)WitsmlMarshal.deserialize(well1311XML, com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWell.class)).getWell();
-        QueryContext qc = new QueryContext(
-            "1.3.1.1", 
-            "well", 
-            null, 
-            well1311XML, 
-            witsmlObjects, 
-            this.username, 
-            this.password
-        );
-
-        // create
-        String uid = this.valve.createObject(qc);
-        assertNotNull(uid);
-        assertEquals("w-1311", uid);
-
-        // mark the well as existing
-        this.well1311exists = true;
+            // create
+            String uid = this.valve.createObject(qc);
+            assertNotNull(uid);
+            assertEquals("w-1311", uid);
+        } catch (ValveException ve) {
+            assertTrue(ve.getMessage().contains("already exists")); // accept the "already exists" response as valid behavior
+        }
 	}
 
     @Test
     public void createObjectWell1411() throws IOException, JAXBException, ValveException{
-        // don't execute if the well exists. This is buggy in DoT right now
-        if (this.well1411exists)
-            return;
+	    try {
+            // get query context
+            String well1411XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1411.xml")));
+            List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWells) WitsmlMarshal.deserialize(well1411XML, com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWell.class)).getWell();
+            QueryContext qc = new QueryContext(
+                    "1.4.1.1",
+                    "well",
+                    null,
+                    well1411XML,
+                    witsmlObjects,
+                    this.username,
+                    this.password
+            );
 
-        // get query context
-        String well1411XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1411.xml")));
-        List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>)((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWells)WitsmlMarshal.deserialize(well1411XML, com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWell.class)).getWell();
-        QueryContext qc = new QueryContext(
-            "1.4.1.1", 
-            "well", 
-            null, 
-            well1411XML, 
-            witsmlObjects, 
-            this.username, 
-            this.password
-        );
-
-        // create
-        String uid = this.valve.createObject(qc);
-        assertNotNull(uid);
-        assertEquals("w-1411", uid);
-
-        // mark the well as existing
-        this.well1411exists = true;
+            // create
+            String uid = this.valve.createObject(qc);
+            assertNotNull(uid);
+            assertEquals("w-1411", uid);
+        } catch (ValveException ve) {
+	        assertTrue(ve.getMessage().contains("already exists")); // accept the "already exists" response as valid behavior
+        }
     }
 
     @Test
@@ -148,7 +137,9 @@ public class DotValveTest {
     @Test
     public void deleteObjectWell1311() throws IOException, JAXBException, ValveException {
 	    // add the deletable object first
-        this.createObjectWell1311();;
+        try {
+            this.createObjectWell1311();
+        } catch (Exception e) {}
 
         // get query context
         String well1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1311.xml")));
@@ -171,7 +162,10 @@ public class DotValveTest {
     @Test
     public void deleteObjectWell1411() throws IOException, JAXBException, ValveException {
         // add the deletable object first
-        this.createObjectWell1411();
+        try {
+            this.createObjectWell1411();
+        } catch (Exception e) {}
+
 
         // get query context
         String well1411XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1411.xml")));
@@ -197,32 +191,40 @@ public class DotValveTest {
     //=========================================================================
     @Test
     public void createObjectWellbore1311() throws IOException, JAXBException, ValveException {
-        // get query context
-        String wellbore1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/wellbore1311.xml")));
-        List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbores) WitsmlMarshal
-                .deserialize(wellbore1311XML, com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbore.class)).getWellbore();
-        QueryContext qc = new QueryContext("1.3.1.1", "wellbore", null, wellbore1311XML, witsmlObjects, this.username,
-                this.password);
+	    try {
+            // get query context
+            String wellbore1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/wellbore1311.xml")));
+            List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbores) WitsmlMarshal
+                    .deserialize(wellbore1311XML, com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbore.class)).getWellbore();
+            QueryContext qc = new QueryContext("1.3.1.1", "wellbore", null, wellbore1311XML, witsmlObjects, this.username,
+                    this.password);
 
-        // create
-        String uid = this.valve.createObject(qc);
-        assertNotNull(uid);
-        assertEquals("b-1311-1", uid);
+            // create
+            String uid = this.valve.createObject(qc);
+            assertNotNull(uid);
+            assertEquals("b-1311-1", uid);
+        } catch (ValveException ve) {
+            assertTrue(ve.getMessage().contains("already exists")); // accept the "already exists" response as valid behavior
+        }
     }
 
     @Test
     public void createObjectWellbore1411() throws IOException, JAXBException, ValveException {
-        // get query context
-        String wellbore1411XML = new String(Files.readAllBytes(Paths.get("src/test/resources/wellbore1411.xml")));
-        List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbores) WitsmlMarshal
-                .deserialize(wellbore1411XML, com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbore.class)).getWellbore();
-        QueryContext qc = new QueryContext("1.4.1.1", "wellbore", null, wellbore1411XML, witsmlObjects, this.username,
-                this.password);
+	    try {
+            // get query context
+            String wellbore1411XML = new String(Files.readAllBytes(Paths.get("src/test/resources/wellbore1411.xml")));
+            List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbores) WitsmlMarshal
+                    .deserialize(wellbore1411XML, com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbore.class)).getWellbore();
+            QueryContext qc = new QueryContext("1.4.1.1", "wellbore", null, wellbore1411XML, witsmlObjects, this.username,
+                    this.password);
 
-        // create
-        String uid = this.valve.createObject(qc);
-        assertNotNull(uid);
-        assertEquals("b-1411-1", uid);
+            // create
+            String uid = this.valve.createObject(qc);
+            assertNotNull(uid);
+            assertEquals("b-1411-1", uid);
+        } catch (ValveException ve) {
+            assertTrue(ve.getMessage().contains("already exists")); // accept the "already exists" response as valid behavior
+        }
     }
     //=========================================================================
 }

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -18,6 +18,7 @@ package com.hashmapinc.tempus.witsml.valve.dot;
 import com.hashmapinc.tempus.WitsmlObjects.Util.WitsmlMarshal;
 import com.hashmapinc.tempus.witsml.QueryContext;
 
+import com.hashmapinc.tempus.witsml.valve.ValveException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,19 +38,30 @@ public class DotValveTest {
 	private String username;
     private String password;
     private DotValve valve;
+    private boolean well1311exists; // indicates if the obj has been put yet
+    private boolean well1411exists; // indicates if the obj has been put yet
 
 	@Before
 	public void doSetup() {
 		this.username = "admin";
         this.password = "12345";
+        this.well1311exists = false;
+        this.well1411exists = false;
         HashMap<String, String> config = new HashMap<>();
-        config.put("baseurl", "http://witsml-qa.hashmapinc.com:8080/"); // TODO: MOCK THIS
+        config.put("baseurl", "http://localhost:8080/"); // TODO: MOCK THIS
         config.put("apikey", "COOLAPIKEY");
 		valve = new DotValve(config);
 	}
 
+    //=========================================================================
+    // WELL
+    //=========================================================================
 	@Test
 	public void createObjectWell1311() throws IOException, JAXBException{
+	    // don't execute if the well exists. This is buggy in DoT right now
+        if (this.well1311exists)
+            return;
+
         // get query context
         String well1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1311.xml")));
         List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>)((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWells)WitsmlMarshal.deserialize(well1311XML, com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWell.class)).getWell();
@@ -66,11 +78,18 @@ public class DotValveTest {
         // create
         String uid = this.valve.createObject(qc);
         assertNotNull(uid);
-        assertEquals("w-12", uid);
+        assertEquals("w-1311", uid);
+
+        // mark the well as existing
+        this.well1311exists = true;
 	}
 
     @Test
     public void createObjectWell1411() throws IOException, JAXBException{
+        // don't execute if the well exists. This is buggy in DoT right now
+        if (this.well1411exists)
+            return;
+
         // get query context
         String well1411XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1411.xml")));
         List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>)((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWells)WitsmlMarshal.deserialize(well1411XML, com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWell.class)).getWell();
@@ -87,40 +106,17 @@ public class DotValveTest {
         // create
         String uid = this.valve.createObject(qc);
         assertNotNull(uid);
-        assertEquals("w-12", uid);
+        assertEquals("w-1411", uid);
+
+        // mark the well as existing
+        this.well1411exists = true;
     }
 
     @Test
-    public void createObjectWellbore1311() throws IOException, JAXBException {
-        // get query context
-        String wellbore1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/wellbore1311.xml")));
-        List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbores) WitsmlMarshal
-                .deserialize(wellbore1311XML, com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbore.class)).getWellbore();
-        QueryContext qc = new QueryContext("1.3.1.1", "wellbore", null, wellbore1311XML, witsmlObjects, this.username,
-                this.password);
-
-        // create
-        String uid = this.valve.createObject(qc);
-        assertNotNull(uid);
-        assertEquals("B-001", uid);
-    }
-
-    @Test
-    public void createObjectWellbore1411() throws IOException, JAXBException {
-        // get query context
-        String wellbore1411XML = new String(Files.readAllBytes(Paths.get("src/test/resources/wellbore1411.xml")));
-        List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbores) WitsmlMarshal
-                .deserialize(wellbore1411XML, com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbore.class)).getWellbore();
-        QueryContext qc = new QueryContext("1.4.1.1", "wellbore", null, wellbore1411XML, witsmlObjects, this.username,
-                this.password);
-
-        // create
-        String uid = this.valve.createObject(qc);
-        assertNotNull(uid);
-        assertEquals("B-01", uid);
-    }
-    
     public void getObjectWell1311() throws IOException, JAXBException {
+        // add the object first
+        this.createObjectWell1311();;
+
         // get query context
         String well1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1311query.xml")));
         List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWells) WitsmlMarshal
@@ -135,6 +131,9 @@ public class DotValveTest {
 
     @Test
     public void getObjectWell1411() throws IOException, JAXBException {
+        // add the object first
+        this.createObjectWell1411();;
+
         // get query context
         String well1411XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1411query.xml")));
         List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWells) WitsmlMarshal
@@ -146,6 +145,87 @@ public class DotValveTest {
         assertNotNull(xmlOut);
         assertFalse(xmlOut.contains("ns0:wells"));
     }
+
+    @Test
+    public void deleteObjectWell1311() throws IOException, JAXBException, ValveException {
+	    // add the deletable object first
+        this.createObjectWell1311();;
+
+        // get query context
+        String well1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1311.xml")));
+        List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWells) WitsmlMarshal
+                .deserialize(well1311XML, com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWell.class)).getWell();
+        QueryContext qc = new QueryContext(
+            null,
+            "well",
+            null,
+            well1311XML,
+            witsmlObjects,
+            this.username,
+            this.password
+        );
+
+        // delete
+        this.valve.deleteObject(qc);
+    }
+
+    @Test
+    public void deleteObjectWell1411() throws IOException, JAXBException, ValveException {
+        // add the deletable object first
+        this.createObjectWell1411();
+
+        // get query context
+        String well1411XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1411.xml")));
+        List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWells) WitsmlMarshal
+                .deserialize(well1411XML, com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWell.class)).getWell();
+        QueryContext qc = new QueryContext(
+            "1.4.1.1",
+            "well",
+            null,
+            well1411XML,
+            witsmlObjects,
+            this.username,
+            this.password
+        );
+
+        // delete
+        this.valve.deleteObject(qc);
+    }
+    //=========================================================================
+
+    //=========================================================================
+    // WELLBORE
+    //=========================================================================
+    @Test
+    public void createObjectWellbore1311() throws IOException, JAXBException {
+        // get query context
+        String wellbore1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/wellbore1311.xml")));
+        List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbores) WitsmlMarshal
+                .deserialize(wellbore1311XML, com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbore.class)).getWellbore();
+        QueryContext qc = new QueryContext("1.3.1.1", "wellbore", null, wellbore1311XML, witsmlObjects, this.username,
+                this.password);
+
+        // create
+        String uid = this.valve.createObject(qc);
+        assertNotNull(uid);
+        assertEquals("b-1311-1", uid);
+    }
+
+    @Test
+    public void createObjectWellbore1411() throws IOException, JAXBException {
+        // get query context
+        String wellbore1411XML = new String(Files.readAllBytes(Paths.get("src/test/resources/wellbore1411.xml")));
+        List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbores) WitsmlMarshal
+                .deserialize(wellbore1411XML, com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbore.class)).getWellbore();
+        QueryContext qc = new QueryContext("1.4.1.1", "wellbore", null, wellbore1411XML, witsmlObjects, this.username,
+                this.password);
+
+        // create
+        String uid = this.valve.createObject(qc);
+        assertNotNull(uid);
+        assertEquals("b-1411-1", uid);
+    }
+    //=========================================================================
 }
 
 

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -104,7 +104,7 @@ public class DotValveTest {
     @Test
     public void getObjectWell1311() throws IOException, JAXBException, ValveException {
         // add the object first
-        this.createObjectWell1311();;
+        this.createObjectWell1311();
 
         // get query context
         String well1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1311query.xml")));
@@ -120,7 +120,7 @@ public class DotValveTest {
     @Test
     public void getObjectWell1411() throws IOException, JAXBException, ValveException {
         // add the object first
-        this.createObjectWell1411();;
+        this.createObjectWell1411();
 
         // get query context
         String well1411XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1411query.xml")));
@@ -156,7 +156,11 @@ public class DotValveTest {
         );
 
         // delete
-        this.valve.deleteObject(qc);
+        try {
+            this.valve.deleteObject(qc);
+        } catch (Exception e) {
+            fail();
+        }
     }
 
     @Test
@@ -182,7 +186,11 @@ public class DotValveTest {
         );
 
         // delete
-        this.valve.deleteObject(qc);
+        try {
+            this.valve.deleteObject(qc);
+        } catch (Exception e) {
+            fail();
+        }
     }
     //=========================================================================
 

--- a/df-valve/src/test/resources/log1311.xml
+++ b/df-valve/src/test/resources/log1311.xml
@@ -15,7 +15,7 @@
 			<FileCreator>John Smith</FileCreator>
 		</FileCreationInformation>
 	</documentInfo>
-	<log uidWell="W-12" uidWellbore="B-01" uid="f34a">
+	<log uidWell="w-1311" uidWellbore="b-1311" uid="l-1311">
 		<nameWell>6507/7-A-42</nameWell>
 		<nameWellbore>A-42</nameWellbore>
 		<name>L001</name>

--- a/df-valve/src/test/resources/log1411.xml
+++ b/df-valve/src/test/resources/log1411.xml
@@ -17,7 +17,7 @@ They totally artificial and are not intended to demonstrate best practices.
 			<fileCreator>John Smith</fileCreator>
 		</fileCreationInformation>
 	</documentInfo>
-	<log uidWell="W-12" uidWellbore="B-01" uid="f34a">
+	<log uidWell="w-1411" uidWellbore="b-1411" uid="l-1411">
 		<nameWell>6507/7-A-42</nameWell>
 		<nameWellbore>A-42</nameWellbore>
 		<name>L001</name>

--- a/df-valve/src/test/resources/trajectory1311.xml
+++ b/df-valve/src/test/resources/trajectory1311.xml
@@ -14,7 +14,7 @@
 			<FileCreator>John Smith</FileCreator>
 		</FileCreationInformation>
 	</documentInfo>
-	<trajectory uidWell="W-12" uidWellbore="B-01" uid="pe84e">
+	<trajectory uidWell="w-1311" uidWellbore="b-1311" uid="t-1311">
 		<nameWell>6507/7-A-42</nameWell>
 		<nameWellbore>A-42</nameWellbore>
 		<name>Plan #2</name>

--- a/df-valve/src/test/resources/trajectory1411.xml
+++ b/df-valve/src/test/resources/trajectory1411.xml
@@ -17,7 +17,7 @@ They totally artificial and are not intended to demonstrate best practices.
 			<fileCreator>John Smith</fileCreator>
 		</fileCreationInformation>
 	</documentInfo>
-	<trajectory uidWell="W-12" uidWellbore="B-01" uid="pe84e">
+	<trajectory uidWell="w-1411" uidWellbore="b-1411" uid="t-1411">
 		<nameWell>6507/7-A-42</nameWell>
 		<nameWellbore>A-42</nameWellbore>
 		<name>Plan #2</name>

--- a/df-valve/src/test/resources/well1311.xml
+++ b/df-valve/src/test/resources/well1311.xml
@@ -14,7 +14,7 @@
 			<FileCreator>John Smith</FileCreator>
 		</FileCreationInformation>
 	</documentInfo>
-	<well uid="w-12">
+	<well uid="w-1311">
 		<name>6507/7-A-42</name>
 		<nameLegal>Company Legal Name</nameLegal>
 		<numLicense>Company License Number</numLicense>

--- a/df-valve/src/test/resources/well1311query.xml
+++ b/df-valve/src/test/resources/well1311query.xml
@@ -14,7 +14,7 @@
 			<FileCreator>John Smith</FileCreator>
 		</FileCreationInformation>
 	</documentInfo>
-	<well uid="w-123">
+	<well uid="w-1311">
 		<name></name>
 	</well>
 </wells>

--- a/df-valve/src/test/resources/well1411.xml
+++ b/df-valve/src/test/resources/well1411.xml
@@ -17,7 +17,7 @@ They totally artificial and are not intended to demonstrate best practices.
 			<fileCreator>John Smith</fileCreator>
 		</fileCreationInformation>
 	</documentInfo>
-	<well uid="w-12">
+	<well uid="w-1411">
 		<name>6507/7-A-42</name>
 		<nameLegal>Company Legal Name</nameLegal>
 		<numLicense>Company License Number</numLicense>

--- a/df-valve/src/test/resources/well1411query.xml
+++ b/df-valve/src/test/resources/well1411query.xml
@@ -17,7 +17,7 @@ They totally artificial and are not intended to demonstrate best practices.
 			<fileCreator>John Smith</fileCreator>
 		</fileCreationInformation>
 	</documentInfo>
-	<well uid="w-123">
+	<well uid="w-1411">
 		<name></name>
 	</well>
 </wells>

--- a/df-valve/src/test/resources/wellbore1311.xml
+++ b/df-valve/src/test/resources/wellbore1311.xml
@@ -14,7 +14,7 @@
 			<FileCreator>John Smith</FileCreator>
 		</FileCreationInformation>
 	</documentInfo>
-	<wellbore uidWell="W-12" uid="B-001">
+	<wellbore uidWell="w-1311" uid="b-1311-1">
 		<nameWell>6507/7-A-42</nameWell>
 		<name>A-42</name>
 		<number>1234-0987</number>
@@ -41,7 +41,7 @@
 			<comments>These are the comments associated with the Wellbore data object.</comments>
 		</commonData>
 	</wellbore>
-	<wellbore uidWell="W-12" uid="B-002">
+	<wellbore uidWell="w-1311" uid="b-1311-2">
 		<nameWell>6507/7-A-42</nameWell>
 		<name>A-43</name>
 		<parentWellbore uidRef="B-001">A-42</parentWellbore>

--- a/df-valve/src/test/resources/wellbore1411.xml
+++ b/df-valve/src/test/resources/wellbore1411.xml
@@ -17,7 +17,7 @@ They totally artificial and are not intended to demonstrate best practices.
 			<fileCreator>John Smith</fileCreator>
 		</fileCreationInformation>
 	</documentInfo>
-	<wellbore uidWell="W-12" uid="B-01">
+	<wellbore uidWell="w-1411" uid="b-1411-1">
 		<nameWell>6507/7-A-42</nameWell>
 		<name>A-42</name>
 		<number>1234-0987</number>
@@ -44,7 +44,7 @@ They totally artificial and are not intended to demonstrate best practices.
 			<comments>These are the comments associated with the Wellbore data object.</comments>
 		</commonData>
 	</wellbore>
-	<wellbore uidWell="W-12" uid="B-02">
+	<wellbore uidWell="w-1411" uid="b-1411-2">
 		<nameWell>6507/7-A-42</nameWell>
 		<name>A-43</name>
 		<parentWellbore uidRef="B-01">A-42</parentWellbore>


### PR DESCRIPTION
This PR includes:
- support for WELL DELETE 
- upgraded DoTValve unit test suite to handle server errors gracefully
- expanded use of `ValveException` in `DotValve` for passing descriptive failure information to SOAP clients
- improved test input XML files

This connects to #126 