### PR TITLE
df-130 -> support DELETE for WELLBORES in DoTValve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ before_install:
 install: 
   - mvn clean install
   - mvn jacoco:report
-cache:
-  directories:
-  - "$HOME/.m2"
 after_success:
   - java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r $TRAVIS_BUILD_DIR/df-server/target/site/jacoco/jacoco.xml
   - mkdir $TRAVIS_BUILD_DIR/out

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ before_install:
 install: 
   - mvn clean install
   - mvn jacoco:report
+cache:
+  directories:
+  - "$HOME/.m2"
 after_success:
   - java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r $TRAVIS_BUILD_DIR/df-server/target/site/jacoco/jacoco.xml
   - mkdir $TRAVIS_BUILD_DIR/out

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
@@ -16,8 +16,6 @@
 package com.hashmapinc.tempus.witsml.valve;
 
 import java.util.Map;
-import java.util.List;
-import java.util.function.Consumer;
 
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.witsml.QueryContext;

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/IValve.java
@@ -17,6 +17,7 @@ package com.hashmapinc.tempus.witsml.valve;
 
 import java.util.Map;
 import java.util.List;
+import java.util.function.Consumer;
 
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.witsml.QueryContext;

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -15,6 +15,7 @@
  */
 package com.hashmapinc.tempus.witsml.valve.dot;
 
+import java.util.ArrayList;
 import java.util.logging.Logger;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
@@ -134,30 +135,26 @@ public class DotValve implements IValve {
     @Override
     public String createObject(
             QueryContext qc
-    ) throws ValveException {
-        // get object information
-        AbstractWitsmlObject obj = qc.WITSML_OBJECTS.get(0); // TODO: don't assume 1 object
-        LOG.info("Creating object: " + obj.toString());
-        String objectType = obj.getObjectType();
-        String objectJSON = this.TRANSLATOR.get1411JSONString(obj);
-
-        // get token
+    ) throws ValveException { // get auth token
         String tokenString;
         try {
             tokenString = this.AUTH.getJWT(qc.USERNAME, qc.PASSWORD).getToken();
         } catch (Exception e) {
-            throw new ValveException("Token error: " + e.getMessage());
+            LOG.warning("Exception in createObject while authenticating: " + e.getMessage());
+            throw new ValveException(e.getMessage());
         }
 
-        // handle each supported object
-        switch (objectType) {
-            case "well":
-                return this.DELEGATOR.addWellToStore(objectJSON, tokenString);
-            case "wellbore":
-                return this.DELEGATOR.addWellboreToStore(objectJSON, tokenString);
-            default:
-                throw new ValveException("Unsupported type encountered in createObject. Type = <" + objectType + ">");
+        // create each object
+        ArrayList<String> uids = new ArrayList<>();
+        try {
+            for (AbstractWitsmlObject witsmlObject: qc.WITSML_OBJECTS)
+                uids.add(this.DELEGATOR.createObject(witsmlObject, tokenString));
+        } catch (Exception e) {
+            LOG.warning("Exception in DotValve create object: " + e.getMessage());
+            throw new ValveException(e.getMessage());
         }
+
+        return uids.get(0); // TODO: handle plural return for creation.
     }
 
     /**
@@ -185,7 +182,6 @@ public class DotValve implements IValve {
             LOG.warning("Got UnirestException in DotValve delete object: " + ue.getMessage());
             throw new ValveException(ue.getMessage());
         }
-
     }
 
     /**

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -257,7 +257,7 @@ public class DotValve implements IValve {
         AbstractWitsmlObject[][] supportedObjects = {
             {well, wellbore}, // ADD TO STORE OBJECTS
             {well}, // GET FROM STORE OBJECTS
-            {well}, // DELETE FROM STORE OBJECTS
+            {well, wellbore}, // DELETE FROM STORE OBJECTS
             {well}, // UPDATE IN STORE OBJECTS
         };
 

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -159,7 +159,7 @@ public class DotValveTest {
         try {
             this.valve.deleteObject(qc);
         } catch (Exception e) {
-            fail();
+            fail(e.getMessage());
         }
     }
 
@@ -189,7 +189,7 @@ public class DotValveTest {
         try {
             this.valve.deleteObject(qc);
         } catch (Exception e) {
-            fail();
+            fail(e.getMessage());
         }
     }
     //=========================================================================
@@ -232,6 +232,73 @@ public class DotValveTest {
             assertEquals("b-1411-1", uid);
         } catch (ValveException ve) {
             assertTrue(ve.getMessage().contains("already exists")); // accept the "already exists" response as valid behavior
+        }
+    }
+
+    @Test
+    public void deleteObjectWellbore1311() throws IOException, JAXBException, ValveException {
+        // add the deletable object first
+        try {
+            this.createObjectWellbore1311();
+        } catch (Exception e) {}
+
+        // get query context
+        String wellbore1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/wellbore1311.xml")));
+        List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbores) WitsmlMarshal
+                .deserialize(wellbore1311XML, com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbore.class)).getWellbore();
+        QueryContext qc = new QueryContext(
+                null,
+                "wellbore",
+                null,
+                wellbore1311XML,
+                witsmlObjects,
+                this.username,
+                this.password
+        );
+
+        // delete
+        try {
+            this.valve.deleteObject(qc);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void deleteObjectWellbore1411() throws IOException, JAXBException, ValveException {
+        // add the deletable object first
+        try {
+            this.createObjectWellbore1411();
+        } catch (Exception e) {}
+
+
+        // get query context
+        String wellbore1411XML = new String(
+            Files.readAllBytes(
+                Paths.get("src/test/resources/wellbore1411.xml")
+            )
+        );
+        List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) (
+            (com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbores)
+            WitsmlMarshal.deserialize(
+                wellbore1411XML, com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbore.class
+            )
+        ).getWellbore();
+        QueryContext qc = new QueryContext(
+            "1.4.1.1",
+            "well",
+            null,
+            wellbore1411XML,
+            witsmlObjects,
+            this.username,
+            this.password
+        );
+
+        // delete
+        try {
+            this.valve.deleteObject(qc);
+        } catch (Exception e) {
+            fail(e.getMessage());
         }
     }
     //=========================================================================

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -44,6 +44,7 @@ public class DotValveTest {
         this.password = "12345";
         HashMap<String, String> config = new HashMap<>();
         config.put("baseurl", "http://witsml-qa.hashmapinc.com:8080/"); // TODO: MOCK THIS
+        //config.put("baseurl", "http://localhost:8080/"); // TODO: MOCK THIS
         config.put("apikey", "COOLAPIKEY");
 		valve = new DotValve(config);
 	}

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -104,8 +104,10 @@ public class DotValveTest {
 
     @Test
     public void getObjectWell1311() throws IOException, JAXBException, ValveException {
-        // add the object first
-        this.createObjectWell1311();
+        // add the deletable object first
+        try {
+            this.createObjectWell1311();
+        } catch (Exception e) {}
 
         // get query context
         String well1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1311query.xml")));
@@ -120,8 +122,10 @@ public class DotValveTest {
 
     @Test
     public void getObjectWell1411() throws IOException, JAXBException, ValveException {
-        // add the object first
-        this.createObjectWell1411();
+        // add the deletable object first
+        try {
+            this.createObjectWell1411();
+        } catch (Exception e) {}
 
         // get query context
         String well1411XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1411query.xml")));


### PR DESCRIPTION
This PR includes:
- refactoring of the `DoTValve.createObject` method to be more concise and to support an arbitrary number of `AbstractWitsmlObject`s
- added support for `wellbore` in `DoTValve` delete
- added test suite for 1311 and 1411 `wellbore` deletion

This connects to #130 