### PR TITLE
Fixing the response objects to more accurately reflect the WMLS wsdl

### DIFF
--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/IStore.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/IStore.java
@@ -75,7 +75,7 @@ public interface IStore {
     @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_GetBaseMsg", operationName = "WMLS_GetBaseMsg")
     @RequestWrapper(targetNamespace = "http://www.witsml.org/message/120")
     @SOAPBinding(style = SOAPBinding.Style.RPC, parameterStyle= SOAPBinding.ParameterStyle.BARE, use = SOAPBinding.Use.ENCODED)
-    String getBaseMsg(@WebParam(partName= "ReturnValueIn") Short ReturnValueIn);
+    WMLS_GetBaseMsgResponse getBaseMsg(@WebParam(partName= "ReturnValueIn") Short ReturnValueIn);
 
     @WebMethod(action = "http://www.witsml.org/action/120/Store.WMLS_GetFromStore", operationName = "WMLS_GetFromStore")
     @RequestWrapper(targetNamespace = "http://www.witsml.org/message/120", localName = "Store.WMLS_GetFromStore")

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -291,14 +291,18 @@ public class StoreImpl implements IStore {
     }
 
     @Override
-    public String getBaseMsg(Short returnValueIn) {
+    public WMLS_GetBaseMsgResponse getBaseMsg(Short returnValueIn) {
         LOG.info("Executing GetBaseMsg");
 
         String errMsg = witsmlApiConfigUtil.getProperty("basemessages." + returnValueIn);
         if (errMsg == null){
             errMsg = witsmlApiConfigUtil.getProperty("basemessages.-999");
         }
-        return errMsg;
+
+        WMLS_GetBaseMsgResponse response = new WMLS_GetBaseMsgResponse();
+        response.setResult(errMsg);
+
+        return response;
     }
 
     @Override

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/model/WMLS_AddToStoreResponse.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/model/WMLS_AddToStoreResponse.java
@@ -15,6 +15,12 @@
  */
 package com.hashmapinc.tempus.witsml.server.api.model;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name="WMLS_AddToStoreResponse")
 public class WMLS_AddToStoreResponse {
     private short Result;
     private String SuppMsgOut;

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/model/WMLS_GetBaseMsgResponse.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/model/WMLS_GetBaseMsgResponse.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2018-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hashmapinc.tempus.witsml.server.api.model;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/model/WMLS_GetBaseMsgResponse.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/model/WMLS_GetBaseMsgResponse.java
@@ -1,0 +1,22 @@
+package com.hashmapinc.tempus.witsml.server.api.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name="WMLS_GetBaseMsgResponse")
+public class WMLS_GetBaseMsgResponse {
+    @XmlElement(name="Result")
+    private String result;
+
+    public String getResult() {
+        return result;
+    }
+
+    public void setResult(String result) {
+        this.result = result;
+    }
+
+}

--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/model/WMLS_UpdateInStoreResponse.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/model/WMLS_UpdateInStoreResponse.java
@@ -15,6 +15,12 @@
  */
 package com.hashmapinc.tempus.witsml.server.api.model;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name="WMLS_UpdateInStoreResponse")
 public class WMLS_UpdateInStoreResponse {
     private short Result;
     private String SuppMsgOut;

--- a/df-server/src/main/resources/logback-spring.xml
+++ b/df-server/src/main/resources/logback-spring.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2018-2018 Hashmap, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+    <property name="LOGS" value="./logs" />
+
+    <appender name="Console"
+              class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %black(%d{ISO8601}) %highlight(%-5level) [%blue(%t)] %yellow(%C{1.}): %msg%n%throwable
+            </Pattern>
+        </layout>
+    </appender>
+
+    <appender name="RollingFile"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOGS}/spring-boot-logger.log</file>
+        <encoder
+                class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
+        </encoder>
+
+        <rollingPolicy
+                class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- rollover daily and when the file reaches 10 MegaBytes -->
+            <fileNamePattern>${LOGS}/archived/spring-boot-logger-%d{yyyy-MM-dd}.%i.log
+            </fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy
+                    class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+        </rollingPolicy>
+    </appender>
+
+    <!-- LOG everything at INFO level -->
+    <root level="info">
+        <appender-ref ref="RollingFile" />
+        <appender-ref ref="Console" />
+    </root>
+
+    <!-- LOG "com.hashmapinc*" at TRACE level -->
+    <logger name="com.hashmapinc" level="trace" additivity="false">
+        <appender-ref ref="RollingFile" />
+        <appender-ref ref="Console" />
+    </logger>
+
+</configuration>

--- a/df-server/src/test/java/com/hashmapinc/tempus/witsml/server/api/StoreImplTests.java
+++ b/df-server/src/test/java/com/hashmapinc/tempus/witsml/server/api/StoreImplTests.java
@@ -71,12 +71,12 @@ public class StoreImplTests {
 
 	@Test
 	public void getBaseMsgShouldReturnATextualDescription(){
-		assertThat(this.witsmlServer.getBaseMsg((short)412)).contains("add");
+		assertThat(this.witsmlServer.getBaseMsg((short)412).getResult()).contains("add");
 	}
 
 	@Test
 	public void getBaseMsgShouldReturnATextualDescriptionForANegativeNumber(){
-		assertThat(this.witsmlServer.getBaseMsg((short)-412)).contains("add");
+		assertThat(this.witsmlServer.getBaseMsg((short)-412).getResult()).contains("add");
 	}
 
 	@Test


### PR DESCRIPTION
This PR resolves #155. 

It adds the response object for get base message, and adds the annotations for the response object types in Update and Add response objects (not super necessary right now, but will avoid some black magic breaking in the near future).