### PR TITLE
df-160 -> force refresh JWT's in DoTValve

### DIFF
--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotAuth.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotAuth.java
@@ -90,9 +90,33 @@ public class DotAuth {
 	 * @return JWT from auth endpoint
 	 * @throws ValveAuthException
 	 */
-	public DecodedJWT getJWT(String username, String password) throws ValveAuthException {
+	public DecodedJWT getJWT(
+		String username,
+		String password
+	) throws ValveAuthException {
 		// refresh token if necessary
 		if (!cache.containsKey(username) || isTokenExpired(username))
+			refreshToken(username, password);
+
+		return cache.get(username);
+	}
+
+	/**
+	 * Refresh the cache if necessary then return the JWT
+	 *
+	 * @param username
+	 * @param password
+	 * @param forceRefresh - boolean indicating if a refresh should be performed
+	 * @return JWT from auth endpoint
+	 * @throws ValveAuthException
+	 */
+	public DecodedJWT getJWT(
+		String username,
+		String password,
+		boolean forceRefresh
+	) throws ValveAuthException {
+		// refresh token if necessary
+		if (forceRefresh || !cache.containsKey(username) || isTokenExpired(username))
 			refreshToken(username, password);
 
 		return cache.get(username);

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -90,7 +90,7 @@ public class DotDelegator {
     public void updateObject(
         AbstractWitsmlObject witsmlObj,
         String tokenString
-    ) throws ValveException, UnirestException {
+    ) throws ValveException, ValveAuthException, UnirestException {
         LOG.info("UPDATING " + witsmlObj.toString() + " in DotDelegator.");
         String uid = witsmlObj.getUid(); // get uid for delete call
         String objectType = witsmlObj.getObjectType(); // get obj type for exception handling
@@ -121,7 +121,10 @@ public class DotDelegator {
         // check response status
         int status = response.getStatus();
         if (201 == status || 200 == status) {
-            LOG.info("Received successful status code from DoT PUT call: " + status);
+            LOG.info("UPDATE for " + witsmlObj + " was successful with REST status code: " + status);
+        } else if (401 == status) {
+            LOG.warning("Bad auth token.");
+            throw new ValveAuthException("Bad JWT");
         } else {
             LOG.warning("Received failure status code from DoT PUT: " + status);
             LOG.warning("PUT response: " + response.getBody());

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -145,7 +145,7 @@ public class DotDelegator {
     public String createObject(
         AbstractWitsmlObject witsmlObj,
         String tokenString
-    ) throws ValveException, UnirestException {
+    ) throws ValveException, ValveAuthException, UnirestException {
         LOG.info("CREATING " + witsmlObj.toString() + " in DotDelegator.");
         String objectType = witsmlObj.getObjectType(); // get obj type for exception handling
         String endpoint; // endpoint to send the call to
@@ -162,7 +162,7 @@ public class DotDelegator {
                 throw new ValveException("Unsupported object type<" + objectType + "> for CREATE");
         }
 
-        // make the UPDATE call.
+        // make the create call.
         String payload = witsmlObj.getJSONString("1.4.1.1");
         HttpResponse<String> response = Unirest
             .post(endpoint)
@@ -177,6 +177,9 @@ public class DotDelegator {
         if (201 == status || 200 == status) {
             LOG.info("Received successful status code from DoT POST call: " + status);
             return new JsonNode(response.getBody()).getObject().getString("uid");
+        } else if (401 == status) {
+            LOG.warning("Bad auth token.");
+            throw new ValveAuthException("Bad JWT");
         } else {
             LOG.warning("Received failure status code from DoT POST: " + status);
             LOG.warning("POST response: " + response.getBody());

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -44,7 +44,7 @@ public class DotDelegator {
     public void deleteObject(
         AbstractWitsmlObject witsmlObj,
         String tokenString
-    ) throws ValveException, UnirestException {
+    ) throws ValveException, UnirestException, ValveAuthException {
         LOG.info("DELETING " + witsmlObj.toString() + " in DotDelegator.");
         String uid = witsmlObj.getUid(); // get uid for delete call
         String objectType = witsmlObj.getObjectType(); // get obj type for exception handling
@@ -74,6 +74,9 @@ public class DotDelegator {
         int status = response.getStatus();
         if (201 == status || 200 == status) {
             LOG.info("Received successful status code from DoT DELETE call: " + status);
+        } else if (401 == status) {
+            LOG.warning("Bad auth token.");
+            throw new ValveAuthException("Bad JWT");
         } else {
             LOG.warning("Received failure status code from DoT DELETE: " + status);
             LOG.warning("DELETE response: " + response.getBody());

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
@@ -81,7 +81,7 @@ public class DotTranslator {
     public static AbstractWitsmlObject translateQueryResponse(
         JSONObject query, 
         JSONObject response
-    ) throws IOException {
+    ) throws ValveException {
         LOG.info("Translating query response.");
 
         // merge the responseJSON with the query
@@ -97,7 +97,11 @@ public class DotTranslator {
 
         // convert the queryJSON back to valid xml
         LOG.info("Converting merged query JSON to valid XML string");
-        return WitsmlMarshal.deserializeFromJSON(query.toString(), com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWell.class);
+        try {
+            return WitsmlMarshal.deserializeFromJSON(query.toString(), com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWell.class);
+        } catch (IOException ioe) {
+            throw new ValveException(ioe.getMessage());
+        }
     }
 
     /**

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
@@ -36,7 +36,7 @@ public class DotTranslator {
      * @param obj - object to serialize
      * @return jsonString - String serialization of a JSON version of the 1.4.1.1 witsml object
      */
-    public String get1411JSONString(AbstractWitsmlObject obj) {
+    public static String get1411JSONString(AbstractWitsmlObject obj) {
         LOG.info("Getting 1.4.1.1 json string for object: " + obj.toString());
         return obj.getJSONString("1.4.1.1");
     }
@@ -46,7 +46,7 @@ public class DotTranslator {
      * @param obj1411 - 1411 AbstractWitsmlObject to serialize to xml
      */
     // TODO: delete this method and use the AbstractWitsmlObject.getXMLString method when version 1.1.5 fixes the namespace bug.
-    public String get1311XMLString(
+    public static String get1311XMLString(
         AbstractWitsmlObject obj1411
     ) throws ValveException {
         LOG.info("getting 1.3.1.1 XML string for object: " + obj1411.toString());
@@ -78,7 +78,7 @@ public class DotTranslator {
      * @param response - JSON object representing the response from DoT
      * @return obj - parsed abstract object
      */
-    public AbstractWitsmlObject translateQueryResponse(
+    public static AbstractWitsmlObject translateQueryResponse(
         JSONObject query, 
         JSONObject response
     ) throws IOException {
@@ -110,7 +110,7 @@ public class DotTranslator {
      * @return = serialized parent object in requested WITSML version format
      * @throws ValveException
      */
-    public String consolidateObjectsToXML(
+    public static String consolidateObjectsToXML(
         ArrayList<AbstractWitsmlObject> witsmlObjects,
         String version
     ) throws ValveException {
@@ -126,7 +126,7 @@ public class DotTranslator {
         String xmlString;
         switch (witsmlObjects.get(0).getObjectType()) {
             case "well": // no consolidation needed for wells
-                xmlString = is1411 ? witsmlObjects.get(0).getXMLString("1.4.1.1") : this.get1311XMLString(witsmlObjects.get(0));
+                xmlString = is1411 ? witsmlObjects.get(0).getXMLString("1.4.1.1") : get1311XMLString(witsmlObjects.get(0));
                 break;
             case "wellbore": // no consolidation needed for wells
                 xmlString = is1411 ? consolidate1411WellboresToXML(witsmlObjects) : consolidate1311WellboresToXML(witsmlObjects);
@@ -138,7 +138,7 @@ public class DotTranslator {
         return xmlString;
     }
 
-    private String consolidate1311WellboresToXML(
+    private static String consolidate1311WellboresToXML(
         ArrayList<AbstractWitsmlObject> witsmlObjects
     ) throws ValveException {
         try {
@@ -160,7 +160,7 @@ public class DotTranslator {
         }
     }
 
-    private String consolidate1411WellboresToXML(
+    private static String consolidate1411WellboresToXML(
         ArrayList<AbstractWitsmlObject> witsmlObjects
     ) throws ValveException {
         try {

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -37,7 +37,6 @@ public class DotValve implements IValve {
     private static final Logger LOG = Logger.getLogger(DotValve.class.getName());
     private final String NAME = "DoT"; // DoT = Drillops Town
     private final String DESCRIPTION = "Valve for interaction with Drillops Town"; // DoT = Drillops Town
-    private final DotTranslator TRANSLATOR;
     private final DotAuth AUTH;
     private final DotDelegator DELEGATOR;
     private final String URL;
@@ -45,8 +44,7 @@ public class DotValve implements IValve {
 
     public DotValve(Map<String, String> config) {
         this.URL = config.get("baseurl");
-        this.API_KEY = config.get("apikey"); 
-        this.TRANSLATOR = new DotTranslator();
+        this.API_KEY = config.get("apikey");
         this.AUTH = new DotAuth(this.URL, this.API_KEY);
         this.DELEGATOR = new DotDelegator(this.URL, this.API_KEY);
     }
@@ -77,7 +75,7 @@ public class DotValve implements IValve {
      */
     @Override
     public String getObject(
-            QueryContext qc
+        QueryContext qc
     ) throws ValveException {
         // TODO: move a ton of this to the delegator.
         // handle each object
@@ -120,7 +118,7 @@ public class DotValve implements IValve {
                     JSONObject queryJSON = new JSONObject(witsmlObject.getJSONString("1.4.1.1"));
                     JSONObject responseJSON = new JsonNode(response.getBody()).getObject();
                     AbstractWitsmlObject mergedResponse =
-                        this.TRANSLATOR.translateQueryResponse(queryJSON, responseJSON);
+                        DotTranslator.translateQueryResponse(queryJSON, responseJSON);
 
                     // add the object to the response list
                     queryResponses.add(mergedResponse);
@@ -137,7 +135,7 @@ public class DotValve implements IValve {
         }
 
         // return consolidated XML response in proper version
-        return this.TRANSLATOR.consolidateObjectsToXML(queryResponses, qc.CLIENT_VERSION);
+        return DotTranslator.consolidateObjectsToXML(queryResponses, qc.CLIENT_VERSION);
     }
 
     /**

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -228,22 +228,18 @@ public class DotValve implements IValve {
     }
 
     /**
-	 * Authenticates with the DotAuth class to get a JWT
+	 * Authenticates with the DotAuth class
 	 * 
-	 * @param userName The user name to authenticate with
+	 * @param username The user name to authenticate with
 	 * @param password The password to authenticate with
 	 * @throws ValveAuthException
 	 */
 	@Override
-	public void authenticate(String userName, String password) throws ValveAuthException {
-		try {
-			AUTH.getJWT(userName, password);
-		} catch (UnirestException e) {
-			e.printStackTrace();
-		} catch (ValveAuthException e) {
-			throw new ValveAuthException(
-					"Username : " + userName + " could not be authenticated. Error in generating JWT token");
-		}
+	public void authenticate(
+        String username,
+        String password
+    ) throws ValveAuthException {
+        this.AUTH.getJWT(username, password);
 	}
 
     /**


### PR DESCRIPTION
This PR includes:
- support for forced token refreshing in DoTAuth
- automatic token refresh and retrying in ALL methods (they catch the bad token 301 from the auth server and retry 1 more time. I can extend this with cooldowns in the future)
- made the DotTranslator an all-static method holder
- moved DotValve getObject logic mostly into the delegator (thanks to the now-static DotTranslator)

This connects to #160 