### PR TITLE
df-164: Integration testing fixes

### DIFF
--- a/df-server/src/main/resources/application.properties
+++ b/df-server/src/main/resources/application.properties
@@ -2,5 +2,4 @@ cxf.path=/Service
 server.port=7070
 wmls.version=1.3.1.1,1.4.1.1
 valve.name=DoT
-valveprop={baseurl:"http://localhost:8080",apikey:"test"}
-dot.auth.apikey=key
+valveprop={baseurl:"http://localhost:8080",apikey:"d838a72bbe684c3bbde1678bb81f35f8"}

--- a/df-server/src/main/resources/application.properties
+++ b/df-server/src/main/resources/application.properties
@@ -2,4 +2,4 @@ cxf.path=/Service
 server.port=7070
 wmls.version=1.3.1.1,1.4.1.1
 valve.name=DoT
-valveprop={baseurl:"http://localhost:8080",apikey:"d838a72bbe684c3bbde1678bb81f35f8"}
+valveprop={baseurl:"http://localhost:8080",apikey:"test"}

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotAuth.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotAuth.java
@@ -60,7 +60,7 @@ public class DotAuth {
 			String payload = "{\"account\":\"" + username + "\", \"password\":\"" + password + "\"}";
 
 			// send request
-			HttpResponse<String> response = Unirest.post(URL)
+			HttpResponse<String> response = Unirest.post(URL + "/token/jwt/v1/")
 				.header("accept", "application/json")
 				.header("Ocp-Apim-Subscription-Key", this.API_KEY)
 				.body(payload)

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -54,7 +54,7 @@ public class DotDelegator {
         // construct the endpoint for each object type
         switch (objectType) { // TODO: add support for wellbore, log, and trajectory
             case "well":
-                endpoint = this.URL + "/witsml/wells/" + uid;
+                endpoint = this.URL + "/democore/well/v2/witsml/wells/" + uid;
                 break;
             case "wellbore":
                 endpoint = this.URL + "/witsml/wellbores/" + uid;
@@ -66,14 +66,13 @@ public class DotDelegator {
         // make the DELETE call.
         HttpResponse<String> response = Unirest
             .delete(endpoint)
-            .header("accept", "application/json")
-            .header("Authorization", tokenString)
-            .header("Ocp-Apim-Subscription-Key", this.API_KEY)
+            .header("Content-Type", "application/json")
+            .header("Authorization", "Bearer " + tokenString)
             .asString();
 
         // check response status
         int status = response.getStatus();
-        if (201 == status || 200 == status) {
+        if (201 == status || 200 == status || 204 == status) {
             LOG.info("Received successful status code from DoT DELETE call: " + status);
         } else if (401 == status) {
             LOG.warning("Bad auth token.");
@@ -103,7 +102,7 @@ public class DotDelegator {
         // construct the endpoint for each object type
         switch (objectType) { // TODO: add support for log and trajectory
             case "well":
-                endpoint = this.URL + "/witsml/wells/" + uid;
+                endpoint = this.URL + "/democore/well/v2/witsml/wells/" + uid;
                 break;
             case "wellbore":
                 endpoint = this.URL + "/witsml/wellbores/" + uid;
@@ -116,9 +115,8 @@ public class DotDelegator {
         String payload = witsmlObj.getJSONString("1.4.1.1");
         HttpResponse<String> response = Unirest
             .put(endpoint)
-            .header("accept", "application/json")
-            .header("Authorization", tokenString)
-            .header("Ocp-Apim-Subscription-Key", this.API_KEY)
+            .header("Content-Type", "application/json")
+            .header("Authorization", "Bearer " + tokenString)
             .body(payload)
             .asString();
 
@@ -154,7 +152,7 @@ public class DotDelegator {
         // construct the endpoint for each object type
         switch (objectType) { // TODO: add support for log and trajectory
             case "well":
-                endpoint = this.URL + "/witsml/wells/";
+                endpoint = this.URL + "/democore/well/v2/witsml/wells/";
                 break;
             case "wellbore":
                 endpoint = this.URL + "/witsml/wellbores/";
@@ -167,9 +165,8 @@ public class DotDelegator {
         String payload = witsmlObj.getJSONString("1.4.1.1");
         HttpResponse<String> response = Unirest
             .post(endpoint)
-            .header("accept", "application/json")
-            .header("Authorization", tokenString)
-            .header("Ocp-Apim-Subscription-Key", this.API_KEY)
+            .header("Content-Type", "application/json")
+            .header("Authorization", "Bearer " + tokenString)
             .body(payload)
             .asString();
 
@@ -207,7 +204,7 @@ public class DotDelegator {
         String endpoint = this.URL;
         switch (objectType) {
             case "well":
-                endpoint += "/witsml/wells/" + uid;
+                endpoint += "/democore/well/v2/witsml/wells/" + uid;
                 break;
             case "wellbore":
                 endpoint += "/witsml/wellbores/" + uid;
@@ -221,8 +218,7 @@ public class DotDelegator {
         // send get
         HttpResponse<String> response = Unirest.get(endpoint)
             .header("accept", "application/json")
-            .header("Authorization", tokenString)
-            .header("Ocp-Apim-Subscription-Key", this.API_KEY)
+            .header("Authorization", "Bearer " + tokenString)
             .asString();
 
         int status = response.getStatus();


### PR DESCRIPTION
This PR resolves #164 by adding Bearer to the Authentication header and removing the OCP key from all except the token broker
It also resolves #165 by updating all the paths for the well api
It finally resolves #166 by changing the key of the content type from accept to Content-Type