### PR TITLE
df-192: adding the exchange id to the query context

### DIFF
--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/api/StoreImpl.java
@@ -29,9 +29,7 @@ import com.hashmapinc.tempus.witsml.valve.ValveFactory;
 import org.apache.cxf.ext.logging.event.LogEvent;
 import org.apache.cxf.feature.Features;
 import org.apache.cxf.message.Message;
-import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.PhaseInterceptorChain;
-import org.apache.cxf.transport.http.AbstractHTTPDestination;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -39,8 +37,6 @@ import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 import javax.jws.WebService;
-import javax.servlet.http.HttpServletRequest;
-import javax.xml.ws.handler.MessageContext;
 
 import java.util.Arrays;
 import java.util.List;
@@ -109,7 +105,7 @@ public class StoreImpl implements IStore {
     private String getExchangeId(){
         Message message = PhaseInterceptorChain.getCurrentMessage();
         if (message == null){
-            return "99999999-9999-9999-9999-999999999999";
+            return "99999999-9999-9999-9999-999999999999"; // TODO: is this smart? (I don't know it isn't, just checking)
         }
         return message.getExchange().get(LogEvent.KEY_EXCHANGE_ID).toString();
     }
@@ -121,7 +117,7 @@ public class StoreImpl implements IStore {
         String OptionsIn,
         String CapabilitiesIn
     ) {
-        LOG.info("Executing addToStore for query" + getExchangeId());
+        LOG.info("Executing addToStore for query <" + getExchangeId() + ">");
         // try to add to store
         List<AbstractWitsmlObject> witsmlObjects;
         String uid;

--- a/df-server/src/main/resources/logback-spring.xml
+++ b/df-server/src/main/resources/logback-spring.xml
@@ -61,7 +61,7 @@
         <appender-ref ref="Console" />
     </logger>
 
-    <logger name="org.apache.cxf" level="warn" additivity="false">
+    <logger name="org.apache.cxf" level="info" additivity="false">
         <appender-ref ref="RollingFile" />
         <appender-ref ref="Console" />
     </logger>

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/QueryContext.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/QueryContext.java
@@ -32,6 +32,7 @@ public class QueryContext {
     public final List<AbstractWitsmlObject> WITSML_OBJECTS;
     public final String USERNAME;
     public final String PASSWORD;
+    public final String EXCHANGE_ID;
     
     /**
      * 
@@ -48,7 +49,8 @@ public class QueryContext {
         Map<String, String> optionsIn, 
         String queryXML,
         String username,
-        String password
+        String password,
+        String exchangeId
     ) {
         // instantiate values
         this.CLIENT_VERSION = clientVersion;
@@ -58,6 +60,7 @@ public class QueryContext {
         this.WITSML_OBJECTS = null;
         this.PASSWORD = password;
         this.USERNAME = username;
+        this.EXCHANGE_ID = exchangeId;
     }
 
     /**
@@ -77,7 +80,8 @@ public class QueryContext {
         String queryXML,
         List<AbstractWitsmlObject> witsmlObjects,
         String username,
-        String password
+        String password,
+        String exchangeId
     ) {
         // instantiate values
         this.CLIENT_VERSION = clientVersion;
@@ -87,5 +91,6 @@ public class QueryContext {
         this.WITSML_OBJECTS = witsmlObjects;
         this.USERNAME = username;
         this.PASSWORD = password;
+        this.EXCHANGE_ID = exchangeId;
     }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -220,6 +220,8 @@ public class DotDelegator {
             .header("Authorization", "Bearer " + tokenString)
             .asString();
 
+        LOG.info("Response for GetObject: " + response.getBody());
+
         int status = response.getStatus();
 
         if (201 == status || 200 == status) {

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -86,7 +86,6 @@ public class DotValve implements IValve {
             LOG.warning("Exception in getObject while authenticating: " + e.getMessage());
             throw new ValveException(e.getMessage());
         }
-
         // handle each object
         ArrayList<AbstractWitsmlObject> queryResponses = new ArrayList<AbstractWitsmlObject>();
         try {
@@ -102,8 +101,6 @@ public class DotValve implements IValve {
             LOG.warning("Exception in DotValve get object: " + e.getMessage());
             throw new ValveException(e.getMessage());
         }
-
-
         // return consolidated XML response in proper version
         return DotTranslator.consolidateObjectsToXML(queryResponses, qc.CLIENT_VERSION);
     }

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 
 import javax.xml.bind.JAXBException;
 
@@ -69,7 +70,8 @@ public class DotValveTest {
                     well1311XML,
                     witsmlObjects,
                     this.username,
-                    this.password
+                    this.password,
+                    UUID.randomUUID().toString()
             );
 
             // create
@@ -94,7 +96,8 @@ public class DotValveTest {
                     well1411XML,
                     witsmlObjects,
                     this.username,
-                    this.password
+                    this.password,
+                    UUID.randomUUID().toString()
             );
 
             // create
@@ -117,7 +120,7 @@ public class DotValveTest {
         String well1311XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1311query.xml")));
         List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWells) WitsmlMarshal
                 .deserialize(well1311XML, com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWell.class)).getWell();
-        QueryContext qc = new QueryContext("1.3.1.1", "well", null, well1311XML, witsmlObjects, this.username, this.password);
+        QueryContext qc = new QueryContext("1.3.1.1", "well", null, well1311XML, witsmlObjects, this.username, this.password, UUID.randomUUID().toString());
 
         // get
         String xmlOut = this.valve.getObject(qc);assertNotNull(xmlOut);
@@ -135,7 +138,7 @@ public class DotValveTest {
         String well1411XML = new String(Files.readAllBytes(Paths.get("src/test/resources/well1411query.xml")));
         List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWells) WitsmlMarshal
                 .deserialize(well1411XML, com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWell.class)).getWell();
-        QueryContext qc = new QueryContext("1.4.1.1", "well", null, well1411XML, witsmlObjects, this.username, this.password);
+        QueryContext qc = new QueryContext("1.4.1.1", "well", null, well1411XML, witsmlObjects, this.username, this.password, UUID.randomUUID().toString());
 
         // get
         String xmlOut = this.valve.getObject(qc);
@@ -161,7 +164,8 @@ public class DotValveTest {
             well1311XML,
             witsmlObjects,
             this.username,
-            this.password
+            this.password,
+            UUID.randomUUID().toString()
         );
 
         // delete
@@ -191,7 +195,8 @@ public class DotValveTest {
             well1411XML,
             witsmlObjects,
             this.username,
-            this.password
+            this.password,
+            UUID.randomUUID().toString()
         );
 
         // delete
@@ -214,7 +219,7 @@ public class DotValveTest {
             List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbores) WitsmlMarshal
                     .deserialize(wellbore1311XML, com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbore.class)).getWellbore();
             QueryContext qc = new QueryContext("1.3.1.1", "wellbore", null, wellbore1311XML, witsmlObjects, this.username,
-                    this.password);
+                    this.password, UUID.randomUUID().toString());
 
             // create
             String uid = this.valve.createObject(qc);
@@ -233,7 +238,7 @@ public class DotValveTest {
             List<AbstractWitsmlObject> witsmlObjects = (List<AbstractWitsmlObject>) (List<?>) ((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbores) WitsmlMarshal
                     .deserialize(wellbore1411XML, com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbore.class)).getWellbore();
             QueryContext qc = new QueryContext("1.4.1.1", "wellbore", null, wellbore1411XML, witsmlObjects, this.username,
-                    this.password);
+                    this.password, UUID.randomUUID().toString());
 
             // create
             String uid = this.valve.createObject(qc);
@@ -266,7 +271,8 @@ public class DotValveTest {
             wellbore1311XML,
             witsmlObjects,
             this.username,
-            this.password
+            this.password,
+            UUID.randomUUID().toString()
         );
 
         // get
@@ -297,7 +303,8 @@ public class DotValveTest {
             well1bore411XML,
             witsmlObjects,
             this.username,
-            this.password
+            this.password,
+            UUID.randomUUID().toString()
         );
 
         // get
@@ -324,7 +331,8 @@ public class DotValveTest {
                 wellbore1311XML,
                 witsmlObjects,
                 this.username,
-                this.password
+                this.password,
+                UUID.randomUUID().toString()
         );
 
         // delete
@@ -362,7 +370,8 @@ public class DotValveTest {
             wellbore1411XML,
             witsmlObjects,
             this.username,
-            this.password
+            this.password,
+            UUID.randomUUID().toString()
         );
 
         // delete


### PR DESCRIPTION
This PR resolves #192 

Currently the exchange id generated by CXF is useful for determining a total round trip time, however, not for understanding the intermediate query performance. Therefore the exchange id has been added to ensure that the query can be tracked from start to finish.