### PR TITLE
DF-183: All endpoints now parameterized

### DIFF
--- a/df-server/src/main/resources/application.yml
+++ b/df-server/src/main/resources/application.yml
@@ -23,5 +23,8 @@ valve :
     configuration :
         baseurl: ${VALVE_BASE_URL}
         apikey: ${VALVE_API_KEY}
+        token.path: token/jwt/v1/
+        well.path: democore/well/v2/witsml/wells/
+        wellbore.path: democore/wellbore/v1/wellbores/
 wmls:
     version: 1.3.1.1,1.4.1.1

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotClient.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotClient.java
@@ -34,6 +34,7 @@ import com.mashape.unirest.request.HttpRequest;
 public class DotClient {
     private static final Logger LOG = Logger.getLogger(DotClient.class.getName());
     private final String URL;
+    private final String TOKEN_PATH;
     private final String API_KEY;
     private Map<String, DecodedJWT> cache;
 
@@ -43,9 +44,10 @@ public class DotClient {
      * @param URL
      * @param API_KEY
      */
-    public DotClient(String URL, String API_KEY) {
+    public DotClient(String URL, String API_KEY, String tokenPath) {
         this.URL = URL;
         this.API_KEY = API_KEY;
+        this.TOKEN_PATH = tokenPath;
         this.cache = new HashMap<String, DecodedJWT>();
     }
 
@@ -64,7 +66,7 @@ public class DotClient {
             String payload = "{\"account\":\"" + username + "\", \"password\":\"" + password + "\"}";
 
             // send request
-            HttpResponse<String> response = Unirest.post(URL + "token/jwt/v1/")
+            HttpResponse<String> response = Unirest.post(URL + this.TOKEN_PATH)
                     .header("accept", "application/json")
                     .header("Ocp-Apim-Subscription-Key", this.API_KEY)
                     .body(payload)

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -15,6 +15,7 @@
  */
 package com.hashmapinc.tempus.witsml.valve.dot;
 
+import java.util.Map;
 import java.util.logging.Logger;
 
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
@@ -32,9 +33,14 @@ public class DotDelegator {
     private static final Logger LOG = Logger.getLogger(DotDelegator.class.getName());
 
     private final String URL;
+    private final String WELL_PATH;
+    private final String WB_PATH;
 
-    public DotDelegator(String url, String apiKey) {
-        this.URL = url;
+
+    public DotDelegator(Map<String, String> config) {
+        this.URL = config.get("baseurl");
+        this.WELL_PATH = config.get("well.path");
+        this.WB_PATH = config.get("wellbore.path");
     }
 
     /**
@@ -51,10 +57,10 @@ public class DotDelegator {
         String endpoint;
         switch (objectType) { // TODO: add support for log and trajectory
             case "well":
-                endpoint = this.URL + "/democore/well/v2/witsml/wells/";
+                endpoint = this.URL + this.WELL_PATH;
                 break;
             case "wellbore":
-                endpoint = this.URL + "/democore/wellbore/v1/witsml/wellbores/";
+                endpoint = this.URL + this.WB_PATH;
                 break;
             default:
                 throw new ValveException("Unsupported object type<" + objectType + ">");

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -41,8 +41,9 @@ public class DotValve implements IValve {
     public DotValve(Map<String, String> config) {
         this.URL = config.get("baseurl");
         this.API_KEY = config.get("apikey");
-        this.CLIENT = new DotClient(this.URL, this.API_KEY);
-        this.DELEGATOR = new DotDelegator(this.URL, this.API_KEY);
+        String tokenPath = config.get("token.path");
+        this.CLIENT = new DotClient(this.URL, this.API_KEY, tokenPath);
+        this.DELEGATOR = new DotDelegator(config);
         LOG.info("Creating valve pointing to url: " + this.URL);
     }
 

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotClientTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotClientTest.java
@@ -37,7 +37,8 @@ public class DotClientTest {
 		String apiKey = "test";
 		//String url = "http://localhost:8080/";
 		String url = "https://witsml.hashmapinc.com:8443/"; // TODO: MOCK THIS
-		dotClient = new DotClient(url, apiKey);
+		String tokenPath = "token/jwt/v1/";
+		dotClient = new DotClient(url, apiKey, tokenPath);
 	}
 
 	@Test

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -52,6 +52,9 @@ public class DotValveTest {
         config.put("baseurl", "https://witsml.hashmapinc.com:8443/"); // TODO: MOCK THIS
         //config.put("baseurl", "http://localhost:8080/"); // TODO: MOCK THIS
         config.put("apikey", "COOLAPIKEY");
+        config.put("well.path", "democore/well/v2/witsml/wells/");
+        config.put("token.path", "token/jwt/v1/");
+        config.put("wellbore.path", "democore/well/v2/witsml/wells/");
 		valve = new DotValve(config);
 	}
 


### PR DESCRIPTION
This PR resolves #183 by parameterizing all rest paths in the valve configuration in the .yml file. It basically changes the constructor of the DotDelegator to take in the config map rather than just the key and the path...this way we can dynamically add more paths as more objects are supported.

The tests were updated to add the new config parameters for the paths.

The endpoints are as follows:

token.path
well.path
wellbore.path