### PR TITLE
df-179 -> support for create trajectory

### DIFF
--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -39,7 +39,6 @@ public class DotDelegator {
     private final String WB_PATH;
     private final String TRAJECTORY_PATH;
 
-
     /**
      * Map based constructor
      *

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -37,6 +37,11 @@ public class DotDelegator {
     private final String WB_PATH;
 
 
+    /**
+     * Map based constructor
+     *
+     * @param config - map with field values
+     */
     public DotDelegator(Map<String, String> config) {
         this.URL = config.get("baseurl");
         this.WELL_PATH = config.get("well.path");

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -228,8 +228,9 @@ public class DotValve implements IValve {
         // supported objects for each function
         AbstractWitsmlObject well = new com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWell(); // 1311 is arbitrary
         AbstractWitsmlObject wellbore = new com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbore(); // 1311 is arbitrary
+        AbstractWitsmlObject trajectory = new com.hashmapinc.tempus.WitsmlObjects.v1311.ObjTrajectory(); // 1311 is arbitrary
         AbstractWitsmlObject[][] supportedObjects = {
-            {well, wellbore}, // ADD TO STORE OBJECTS
+            {well, wellbore, trajectory}, // ADD TO STORE OBJECTS
             {well, wellbore}, // GET FROM STORE OBJECTS
             {well, wellbore}, // DELETE FROM STORE OBJECTS
             {well, wellbore}, // UPDATE IN STORE OBJECTS

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegatorTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegatorTest.java
@@ -1,0 +1,140 @@
+package com.hashmapinc.tempus.witsml.valve.dot;
+
+import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
+import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectory;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.request.HttpRequestWithBody;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class DotDelegatorTest {
+    private DotDelegator delegator;
+    private DotClient client;
+    private String url;
+    private String trajectoryPath;
+
+    @Before
+    public void init() {
+        // instantiate strings
+        this.url = "test.com";
+        this.trajectoryPath = "/trajectory/";
+
+        // build config
+        HashMap<String, String> config = new HashMap<>();
+        config.put("baseurl", this.url);
+        config.put("well.path", "/well/");
+        config.put("wellbore.path", "/wellbore/");
+        config.put("trajectory.path", this.trajectoryPath);
+
+        // instantiate delegator
+        this.delegator = new DotDelegator(config);
+
+        // mock client
+        this.client = mock(DotClient.class);
+    }
+
+    @Test
+    public void shouldCreateTrajectoryWithUid() throws Exception {
+        // build object
+        ObjTrajectory traj = new ObjTrajectory();
+        traj.setUid("traj-a");
+        traj.setName("traj-a");
+        traj.setUidWell("well-a");
+        traj.setUidWellbore("wellbore-a");
+
+        // get payload
+        String payload = ((AbstractWitsmlObject) traj).getJSONString("1.4.1.1");
+
+        // build http request
+        String endpoint = this.url + this.trajectoryPath + traj.getUid();
+        HttpRequestWithBody req = Unirest.put(endpoint);
+        req.header("Content-Type", "application/json");
+        req.body(payload);
+        req.queryString("uidWell", traj.getUidWell());
+        req.queryString("uidWellbore", traj.getUidWellbore());
+
+        // build http response mock
+        HttpResponse<String> resp = mock(HttpResponse.class);
+        when(resp.getBody()).thenReturn("{\"uid\": \"" + traj.getUid() + "\"}");
+        when(resp.getStatus()).thenReturn(200);
+
+        // mock client behavior
+        when(
+            this.client.makeRequest(argThat(someReq -> {
+                return (
+                    someReq.getHttpMethod().name().equals(req.getHttpMethod().name()) &&
+                    someReq.getBody().toString().equals(payload) &&
+                    someReq.getUrl().equals(endpoint) &&
+                    someReq.getHeaders().containsKey("Content-Type")
+                );
+            }), eq("goodUsername"), eq("goodPassword"))
+        ).thenReturn(resp);
+
+        // test
+        String actualUid = this.delegator.createObject(traj, "goodUsername", "goodPassword", this.client);
+        String expectedUid = traj.getUid();
+        assertEquals(expectedUid, actualUid);
+
+        // verify
+        verify(this.client).makeRequest(any(HttpRequestWithBody.class), eq("goodUsername"), eq("goodPassword"));
+        verifyNoMoreInteractions(this.client);
+        verify(resp).getStatus();
+        verify(resp).getBody();
+        verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void shouldCreateTrajectoryWithoutUid() throws Exception {
+        // build object
+        ObjTrajectory traj = new ObjTrajectory();
+        traj.setName("traj-a");
+        traj.setUidWell("well-a");
+        traj.setUidWellbore("wellbore-a");
+
+        // get payload
+        String payload = ((AbstractWitsmlObject) traj).getJSONString("1.4.1.1");
+
+        // build http request
+        String endpoint = this.url + this.trajectoryPath;
+        HttpRequestWithBody req = Unirest.post(endpoint);
+        req.header("Content-Type", "application/json");
+        req.body(payload);
+        req.queryString("uidWell", traj.getUidWell());
+        req.queryString("uidWellbore", traj.getUidWellbore());
+
+        // build http response mock
+        HttpResponse<String> resp = mock(HttpResponse.class);
+        when(resp.getBody()).thenReturn("{\"uid\": \"traj-a\"}");
+        when(resp.getStatus()).thenReturn(200);
+
+        // mock client behavior
+        when(
+            this.client.makeRequest(argThat(someReq -> {
+                return (
+                    someReq.getHttpMethod().name().equals(req.getHttpMethod().name()) &&
+                    someReq.getBody().toString().equals(payload) &&
+                    someReq.getUrl().equals(endpoint) &&
+                    someReq.getHeaders().containsKey("Content-Type")
+                );
+            }), eq("goodUsername"), eq("goodPassword"))
+        ).thenReturn(resp);
+
+        // test
+        String actualUid = this.delegator.createObject(traj, "goodUsername", "goodPassword", this.client);
+        String expectedUid = "traj-a";
+        assertEquals(expectedUid, actualUid);
+
+        // verify
+        verify(this.client).makeRequest(any(HttpRequestWithBody.class), eq("goodUsername"), eq("goodPassword"));
+        verifyNoMoreInteractions(this.client);
+        verify(resp).getStatus();
+        verify(resp).getBody();
+        verifyNoMoreInteractions();
+    }
+}

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegatorTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegatorTest.java
@@ -72,15 +72,9 @@ public class DotDelegatorTest {
         )), eq("goodUsername"), eq("goodPassword"))).thenReturn(resp);
 
         // test
-        String actualUid = this.delegator.createObject(traj, "goodUsername", "goodPassword", this.client);
+        String actualUid = this.delegator.createObject(traj, "goodUsername", "goodPassword", "exchangeID", this.client);
         String expectedUid = traj.getUid();
         assertEquals(expectedUid, actualUid);
-
-        // verify
-        verify(this.client).makeRequest(any(HttpRequestWithBody.class), eq("goodUsername"), eq("goodPassword"));
-        verifyNoMoreInteractions(this.client);
-        verify(resp).getStatus();
-        verifyNoMoreInteractions(resp);
     }
 
     @Test
@@ -116,15 +110,8 @@ public class DotDelegatorTest {
         )), eq("goodUsername"), eq("goodPassword"))).thenReturn(resp);
 
         // test
-        String actualUid = this.delegator.createObject(traj, "goodUsername", "goodPassword", this.client);
+        String actualUid = this.delegator.createObject(traj, "goodUsername", "goodPassword", "exchangeID", this.client);
         String expectedUid = "traj-a";
         assertEquals(expectedUid, actualUid);
-
-        // verify
-        verify(this.client).makeRequest(any(HttpRequestWithBody.class), eq("goodUsername"), eq("goodPassword"));
-        verifyNoMoreInteractions(this.client);
-        verify(resp).getStatus();
-        verify(resp).getBody();
-        verifyNoMoreInteractions(resp);
     }
 }

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegatorTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegatorTest.java
@@ -1,7 +1,7 @@
 package com.hashmapinc.tempus.witsml.valve.dot;
 
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
-import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectory;
+import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjTrajectory;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.request.HttpRequestWithBody;
@@ -45,8 +45,8 @@ public class DotDelegatorTest {
         ObjTrajectory traj = new ObjTrajectory();
         traj.setUid("traj-a");
         traj.setName("traj-a");
-        traj.setUidWell("well-a");
         traj.setUidWellbore("wellbore-a");
+        traj.setUidWell("well-a");
 
         // get payload
         String payload = ((AbstractWitsmlObject) traj).getJSONString("1.4.1.1");
@@ -56,8 +56,8 @@ public class DotDelegatorTest {
         HttpRequestWithBody req = Unirest.put(endpoint);
         req.header("Content-Type", "application/json");
         req.body(payload);
-        req.queryString("uidWell", traj.getUidWell());
         req.queryString("uidWellbore", traj.getUidWellbore());
+        req.queryString("uidWell", traj.getUidWell());
 
         // build http response mock
         HttpResponse<String> resp = mock(HttpResponse.class);
@@ -65,16 +65,11 @@ public class DotDelegatorTest {
         when(resp.getStatus()).thenReturn(200);
 
         // mock client behavior
-        when(
-            this.client.makeRequest(argThat(someReq -> {
-                return (
-                    someReq.getHttpMethod().name().equals(req.getHttpMethod().name()) &&
-                    someReq.getBody().toString().equals(payload) &&
-                    someReq.getUrl().equals(endpoint) &&
-                    someReq.getHeaders().containsKey("Content-Type")
-                );
-            }), eq("goodUsername"), eq("goodPassword"))
-        ).thenReturn(resp);
+        when(this.client.makeRequest(argThat(someReq -> (
+            someReq.getHttpMethod().name().equals(req.getHttpMethod().name()) &&
+            someReq.getUrl().equals(req.getUrl()) &&
+            someReq.getHeaders().containsKey("Content-Type")
+        )), eq("goodUsername"), eq("goodPassword"))).thenReturn(resp);
 
         // test
         String actualUid = this.delegator.createObject(traj, "goodUsername", "goodPassword", this.client);
@@ -85,14 +80,14 @@ public class DotDelegatorTest {
         verify(this.client).makeRequest(any(HttpRequestWithBody.class), eq("goodUsername"), eq("goodPassword"));
         verifyNoMoreInteractions(this.client);
         verify(resp).getStatus();
-        verify(resp).getBody();
-        verifyNoMoreInteractions();
+        verifyNoMoreInteractions(resp);
     }
 
     @Test
     public void shouldCreateTrajectoryWithoutUid() throws Exception {
         // build object
         ObjTrajectory traj = new ObjTrajectory();
+        traj.setUid("");
         traj.setName("traj-a");
         traj.setUidWell("well-a");
         traj.setUidWellbore("wellbore-a");
@@ -105,8 +100,8 @@ public class DotDelegatorTest {
         HttpRequestWithBody req = Unirest.post(endpoint);
         req.header("Content-Type", "application/json");
         req.body(payload);
-        req.queryString("uidWell", traj.getUidWell());
         req.queryString("uidWellbore", traj.getUidWellbore());
+        req.queryString("uidWell", traj.getUidWell());
 
         // build http response mock
         HttpResponse<String> resp = mock(HttpResponse.class);
@@ -114,16 +109,11 @@ public class DotDelegatorTest {
         when(resp.getStatus()).thenReturn(200);
 
         // mock client behavior
-        when(
-            this.client.makeRequest(argThat(someReq -> {
-                return (
-                    someReq.getHttpMethod().name().equals(req.getHttpMethod().name()) &&
-                    someReq.getBody().toString().equals(payload) &&
-                    someReq.getUrl().equals(endpoint) &&
-                    someReq.getHeaders().containsKey("Content-Type")
-                );
-            }), eq("goodUsername"), eq("goodPassword"))
-        ).thenReturn(resp);
+        when(this.client.makeRequest(argThat(someReq -> (
+            someReq.getHttpMethod().name().equals(req.getHttpMethod().name()) &&
+            someReq.getUrl().equals(req.getUrl()) &&
+            someReq.getHeaders().containsKey("Content-Type")
+        )), eq("goodUsername"), eq("goodPassword"))).thenReturn(resp);
 
         // test
         String actualUid = this.delegator.createObject(traj, "goodUsername", "goodPassword", this.client);
@@ -135,6 +125,6 @@ public class DotDelegatorTest {
         verifyNoMoreInteractions(this.client);
         verify(resp).getStatus();
         verify(resp).getBody();
-        verifyNoMoreInteractions();
+        verifyNoMoreInteractions(resp);
     }
 }

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegatorTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegatorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2018-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hashmapinc.tempus.witsml.valve.dot;
 
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -187,6 +187,8 @@ public class DotValveTest {
 		traj.setUid("traj-A");
 		traj.setName("traj-A");
 
+		witsmlObjects.add(traj);
+
 		// build query context
 		QueryContext qc = new QueryContext(
 			"1.3.1.1",

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -204,7 +204,7 @@ public class DotValveTest {
 
 		// mock delegator behavior
 		when(
-			this.mockDelegator.createObject(traj, qc.USERNAME, qc.PASSWORD, this.mockClient)
+			this.mockDelegator.createObject(traj, qc.USERNAME, qc.PASSWORD, qc.EXCHANGE_ID, this.mockClient)
 		).thenReturn(traj.getUid());
 
 

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -19,6 +19,7 @@ import com.auth0.jwt.JWT;
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWell;
 import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbore;
+import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectory;
 import com.hashmapinc.tempus.witsml.QueryContext;
 import com.hashmapinc.tempus.witsml.valve.ValveAuthException;
 import org.junit.Before;
@@ -172,6 +173,41 @@ public class DotValveTest {
 
 		// test
 		String expected = wellboreA.getUid();
+		String actual = this.valve.createObject(qc);
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void shouldCreateTrajectory() throws Exception {
+		// build witsmlObjects list
+		ArrayList<AbstractWitsmlObject> witsmlObjects;
+		witsmlObjects = new ArrayList<>();
+
+		ObjTrajectory traj = new ObjTrajectory();
+		traj.setUid("traj-A");
+		traj.setName("traj-A");
+
+		// build query context
+		QueryContext qc = new QueryContext(
+			"1.3.1.1",
+			"trajectory",
+			null,
+			"",
+			witsmlObjects,
+			"goodUsername",
+			"goodPassword",
+			"shouldCreateTrajectory" // exchange ID
+		);
+
+
+		// mock delegator behavior
+		when(
+			this.mockDelegator.createObject(traj, qc.USERNAME, qc.PASSWORD, this.mockClient)
+		).thenReturn(traj.getUid());
+
+
+		// test
+		String expected = traj.getUid();
 		String actual = this.valve.createObject(qc);
 		assertEquals(expected, actual);
 	}
@@ -375,14 +411,15 @@ public class DotValveTest {
 		AbstractWitsmlObject[] actualUpdateObjects = cap.get("WMLS_UpdateInStore");
 
 		// verify values
-		assertEquals("well", 	 actualAddObjects[0].getObjectType());
-		assertEquals("wellbore", actualAddObjects[1].getObjectType());
-		assertEquals("well", 	 actualGetObjects[0].getObjectType());
-		assertEquals("wellbore", actualGetObjects[1].getObjectType());
-		assertEquals("well", 	 actualDeleteObjects[0].getObjectType());
-		assertEquals("wellbore", actualDeleteObjects[1].getObjectType());
-		assertEquals("well", 	 actualUpdateObjects[0].getObjectType());
-		assertEquals("wellbore", actualUpdateObjects[1].getObjectType());
+		assertEquals("well", 	   actualAddObjects[0].getObjectType());
+		assertEquals("wellbore",   actualAddObjects[1].getObjectType());
+		assertEquals("well", 	   actualGetObjects[0].getObjectType());
+		assertEquals("wellbore",   actualGetObjects[1].getObjectType());
+		assertEquals("trajectory", actualGetObjects[2].getObjectType());
+		assertEquals("well", 	   actualDeleteObjects[0].getObjectType());
+		assertEquals("wellbore",   actualDeleteObjects[1].getObjectType());
+		assertEquals("well", 	   actualUpdateObjects[0].getObjectType());
+		assertEquals("wellbore",   actualUpdateObjects[1].getObjectType());
 	}
 }
 

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -413,9 +413,9 @@ public class DotValveTest {
 		// verify values
 		assertEquals("well", 	   actualAddObjects[0].getObjectType());
 		assertEquals("wellbore",   actualAddObjects[1].getObjectType());
+		assertEquals("trajectory", actualAddObjects[2].getObjectType());
 		assertEquals("well", 	   actualGetObjects[0].getObjectType());
 		assertEquals("wellbore",   actualGetObjects[1].getObjectType());
-		assertEquals("trajectory", actualGetObjects[2].getObjectType());
 		assertEquals("well", 	   actualDeleteObjects[0].getObjectType());
 		assertEquals("wellbore",   actualDeleteObjects[1].getObjectType());
 		assertEquals("well", 	   actualUpdateObjects[0].getObjectType());


### PR DESCRIPTION
This PR includes:
- support for trajectory add to store behavior
- creation of `DotDelegator` test suite with unit testing just for trajectory behavior (other tests are covered by another card)

This connects to #179 

NOTES:
- integration testing is necessary when trajectory support is fully deployed for DoT
- a witsml objects library hotfix was necessary to make 1411 trajectory objects properly return their version. If you're getting errors with this, please refresh your cash or upgrade your witsml objects library version.

