### PR TITLE
df-218 -> fix bad well merging, support drillflow responses for non-error 404 DoT statuses

### DIFF
--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -290,6 +290,9 @@ public class DotDelegator {
 			JSONObject queryJSON = new JSONObject(witsmlObject.getJSONString("1.4.1.1"));
 			JSONObject responseJSON = new JsonNode(response.getBody()).getObject();
 			return DotTranslator.translateQueryResponse(queryJSON, responseJSON, objectType);
+		} else if (404 == status) {
+			// handle not found. This is a valid response
+			return null;
 		} else {
 			ValveLogging valveLoggingResponse = new ValveLogging(witsmlObject.getUid(),
 					logResponse(response, "Unable to execute GET"), witsmlObject);

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
@@ -25,6 +25,8 @@ import com.hashmapinc.tempus.WitsmlObjects.Util.WitsmlMarshal;
 import com.hashmapinc.tempus.witsml.valve.ValveException;
 import org.json.JSONObject;
 
+import javax.xml.bind.JAXBException;
+
 /**
  * ABANDON ALL HOPE, YE WHO ENTER HERE
  */
@@ -109,39 +111,108 @@ public class DotTranslator {
     }
 
     /**
+     * converts witsmlObjects list of wells to valid
+     * witsml XML string based on version and whether
+     * the list is empty or not
+     * @param witsmlObjects - list of wells to serialize. Should be 1 or 0 wells
+     * @param version - witsml version to serialize to
+     * @return STRING xml serialization result
+     * @throws ValveException
+     */
+    private static String consolidateWellsToXML(
+        ArrayList<AbstractWitsmlObject> witsmlObjects,
+        String version
+    ) throws ValveException {
+        String xml;
+        boolean is1411 = "1.4.1.1".equals(version);
+
+        // handle empty well list
+        if (0 == witsmlObjects.size()) {
+            try {
+                xml = is1411 ?
+                    WitsmlMarshal.serialize(new com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWells()) :
+                    WitsmlMarshal.serialize(new com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWells());
+            } catch (JAXBException jxbe) {
+                throw new ValveException("Could not serialize empty wells object");
+            }
+
+
+        } else {
+            // handle non empty well list
+            xml = is1411 ?
+                witsmlObjects.get(0).getXMLString("1.4.1.1") :
+                get1311WitsmlObject(witsmlObjects.get(0)).getXMLString("1.3.1.1");
+        }
+
+        return xml;
+    }
+
+    /**
+     * converts witsmlObjects list of wellbores to valid
+     * witsml XML string based on version and whether
+     * the list is empty or not
+     * @param witsmlObjects - list of objects to serialize
+     * @param version - witsml version to serialize to
+     * @return STRING xml serialization result
+     * @throws ValveException
+     */
+    private static String consolidateWellboresToXML(
+        ArrayList<AbstractWitsmlObject> witsmlObjects,
+        String version
+    ) throws ValveException {
+        String xml;
+        boolean is1411 = "1.4.1.1".equals(version);
+
+        // handle empty list
+        if (0 == witsmlObjects.size()) {
+            try {
+                xml = is1411 ?
+                    WitsmlMarshal.serialize(new com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbores()) :
+                    WitsmlMarshal.serialize(new com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbores());
+            } catch (JAXBException jxbe) {
+                throw new ValveException("Could not serialize empty wellbores object");
+            }
+
+
+        } else {
+            // handle non empty list
+            xml = is1411 ?
+                consolidate1411WellboresToXML(witsmlObjects) :
+                consolidate1311WellboresToXML(witsmlObjects);
+        }
+
+        return xml;
+    }
+
+    /**
      * Consolidates each object under 1 parent and serializes
      * the consolidated object into an XML string in the proper
      * WITSML version format
      *
      * @param witsmlObjects - list of objects to consolidate
      * @param version - witsml version to serialize to
+     * @param objectType - type of objects being consolidated (well, wellbore, trajectory, or log)
      * @return = serialized parent object in requested WITSML version format
      * @throws ValveException
      */
     public static String consolidateObjectsToXML(
         ArrayList<AbstractWitsmlObject> witsmlObjects,
-        String version
+        String version,
+        String objectType
     ) throws ValveException {
         // validate version
         if(!"1.3.1.1".equals(version) && !"1.4.1.1".equals(version)) {
             throw new ValveException("Unsupported client version <" + version + "> in DoT GET");
         }
 
-        // makes if statements more legible
-        boolean is1411 = "1.4.1.1".equals(version);
-
         // get xmlString
         String xmlString;
-        switch (witsmlObjects.get(0).getObjectType()) {
+        switch (objectType) {
             case "well": // no consolidation needed for wells
-                xmlString = is1411 ?
-                    witsmlObjects.get(0).getXMLString("1.4.1.1") :
-                    get1311WitsmlObject(witsmlObjects.get(0)).getXMLString("1.3.1.1");
+                xmlString = consolidateWellsToXML(witsmlObjects, version);
                 break;
             case "wellbore": // no consolidation needed for wells
-                xmlString = is1411 ?
-                    consolidate1411WellboresToXML(witsmlObjects) :
-                    consolidate1311WellboresToXML(witsmlObjects);
+                xmlString = consolidateWellboresToXML(witsmlObjects, version);
                 break;
             default:
                 throw new ValveException("Unsupported object type: " + witsmlObjects.get(0).getObjectType());

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -98,22 +98,21 @@ public class DotValve implements IValve {
         ArrayList<AbstractWitsmlObject> queryResponses = new ArrayList<AbstractWitsmlObject>();
         try {
             for (AbstractWitsmlObject witsmlObject: qc.WITSML_OBJECTS) {
-                queryResponses.add(
-                    this.DELEGATOR.getObject(
-                        witsmlObject,
-                        qc.USERNAME,
-                        qc.PASSWORD,
-                        qc.EXCHANGE_ID,
-                        this.CLIENT
-                    )
+                AbstractWitsmlObject response = this.DELEGATOR.getObject(
+                    witsmlObject,
+                    qc.USERNAME,
+                    qc.PASSWORD,
+                    qc.EXCHANGE_ID,
+                    this.CLIENT
                 );
+                if (null != response) queryResponses.add(response);
             }
         } catch (Exception e) {
             LOG.warning("Exception in DotValve get object: " + e.getMessage());
             throw new ValveException(e.getMessage());
         }
         // return consolidated XML response in proper version
-        return DotTranslator.consolidateObjectsToXML(queryResponses, qc.CLIENT_VERSION);
+        return DotTranslator.consolidateObjectsToXML(queryResponses, qc.CLIENT_VERSION, qc.OBJECT_TYPE);
     }
 
     /**

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/Util.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/Util.java
@@ -91,7 +91,18 @@ public class Util {
         if (obj instanceof String) return ((String) obj).isEmpty();
 
         // handle json array
-        if (obj instanceof JSONArray) return ((JSONArray) obj).length() == 0;
+        if (obj instanceof JSONArray) {
+            JSONArray objArray = (JSONArray) obj;
+            if (objArray.length() == 0)
+                return true;
+
+            // check if elements are empty too
+            boolean elementsAreEmpty = true;
+            for (int i = 0; i < objArray.length(); i++ )
+                elementsAreEmpty &= isEmpty(objArray.get(i));
+
+            return elementsAreEmpty;
+        }
 
         // handle json objects
         if (obj instanceof JSONObject) {

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -17,8 +17,10 @@ package com.hashmapinc.tempus.witsml.valve.dot;
 
 import com.auth0.jwt.JWT;
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
+import com.hashmapinc.tempus.WitsmlObjects.Util.WitsmlMarshal;
 import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWell;
 import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbore;
+import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWells;
 import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectory;
 import com.hashmapinc.tempus.witsml.QueryContext;
 import com.hashmapinc.tempus.witsml.valve.ValveAuthException;
@@ -85,6 +87,39 @@ public class DotValveTest {
 
 		// test
 		String expected = well.getXMLString("1.3.1.1");
+		String actual = this.valve.getObject(qc);
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void shouldGetEmptyObject() throws Exception {
+		// build well list
+		ArrayList<AbstractWitsmlObject> witsmlObjects;
+		witsmlObjects = new ArrayList<>();
+		ObjWell well = new ObjWell();
+		well.setName("well-1");
+		well.setUid("well-1");
+		witsmlObjects.add(well);
+
+		// build query context
+		QueryContext qc = new QueryContext(
+			"1.3.1.1",
+			"well",
+			null,
+			"",
+			witsmlObjects,
+			"goodUsername",
+			"goodPassword",
+			"shouldGetEmptyObject" // exchange ID
+		);
+
+		// mock delegator behavior
+		when(
+			this.mockDelegator.getObject(well, qc.USERNAME, qc.PASSWORD,qc.EXCHANGE_ID, this.mockClient)
+		).thenReturn(null);
+
+		// test
+		String expected = WitsmlMarshal.serialize(new ObjWells());
 		String actual = this.valve.getObject(qc);
 		assertEquals(expected, actual);
 	}

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/UtilTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/UtilTest.java
@@ -1,0 +1,29 @@
+package com.hashmapinc.tempus.witsml.valve.dot;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class UtilTest {
+
+    @Test
+    public void shouldProperlyMerge1311Well() throws Exception {
+        String destString = new String(Files.readAllBytes(Paths.get("src/test/resources/utilTest/well1311dest.json")));
+        String srcString = new String(Files.readAllBytes(Paths.get("src/test/resources/utilTest/well1311src.json")));
+
+        JSONObject dest = new JSONObject(destString);
+        JSONObject src = new JSONObject(srcString);
+
+        JSONObject merged = Util.merge(dest, src);
+
+        String actual = merged.toString(2);
+        String expected = new String(Files.readAllBytes(Paths.get("src/test/resources/utilTest/well1311merged.json")));
+
+        assertEquals(expected, actual);
+    }
+}
+

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/UtilTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/UtilTest.java
@@ -25,5 +25,22 @@ public class UtilTest {
 
         assertEquals(expected, actual);
     }
+
+
+    @Test
+    public void shouldReturnEmptyMergeObject() throws Exception {
+        String destString = "{\"fakeField\": null}";
+        String srcString = new String(Files.readAllBytes(Paths.get("src/test/resources/utilTest/well1311src.json")));
+
+        JSONObject dest = new JSONObject(destString);
+        JSONObject src = new JSONObject(srcString);
+
+        JSONObject merged = Util.merge(dest, src);
+
+        String actual = merged.toString(2);
+        String expected = "{}";
+
+        assertEquals(expected, actual);
+    }
 }
 

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/UtilTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/UtilTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2018-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hashmapinc.tempus.witsml.valve.dot;
 
 import org.json.JSONObject;

--- a/df-valve/src/test/resources/utilTest/well1311dest.json
+++ b/df-valve/src/test/resources/utilTest/well1311dest.json
@@ -241,7 +241,7 @@
             "uid": null,
             "uom": "",
             "name": "",
-            "index": 0,
+            "index": null,
             "description": "",
             "value": ""
           }

--- a/df-valve/src/test/resources/utilTest/well1311dest.json
+++ b/df-valve/src/test/resources/utilTest/well1311dest.json
@@ -1,0 +1,370 @@
+{
+  "country": "",
+  "numLicense": "",
+  "county": "",
+  "waterDepth": {
+    "uom": null,
+    "value": null
+  },
+  "operator": "",
+  "pcInterest": {
+    "uom": "",
+    "value": null
+  },
+  "objectType": "well",
+  "uid": "uid12333",
+  "nameLegal": "",
+  "block": "",
+  "state": "",
+  "operatorDiv": "",
+  "groundElevation": {
+    "datum": "",
+    "uom": null,
+    "value": null
+  },
+  "commonData": {
+    "comments": "",
+    "acquisitionTimeZone": [],
+    "extensionNameValue": []
+  },
+  "timeZone": "",
+  "numAPI": "",
+  "version": "1.4.1.1",
+  "referencePoint": [
+    {
+      "elevation": {
+        "datum": "",
+        "uom": null,
+        "value": null
+      },
+      "uid": "",
+      "measuredDepth": {
+        "datum": "",
+        "uom": null,
+        "value": null
+      },
+      "name": "",
+      "description": "",
+      "location": [
+        {
+          "southing": {
+            "uom": "",
+            "value": null
+          },
+          "easting": {
+            "uom": "",
+            "value": null
+          },
+          "latitude": {
+            "uom": "",
+            "value": null
+          },
+          "description": "",
+          "extensionNameValue": [],
+          "northing": {
+            "uom": "",
+            "value": null
+          },
+          "uid": null,
+          "projectedX": {
+            "uom": "",
+            "value": null
+          },
+          "wellCRS": {
+            "value": "",
+            "uidRef": ""
+          },
+          "projectedY": {
+            "uom": "",
+            "value": null
+          },
+          "localY": {
+            "uom": "",
+            "value": null
+          },
+          "westing": {
+            "uom": "",
+            "value": null
+          },
+          "localX": {
+            "uom": "",
+            "value": null
+          },
+          "longitude": {
+            "uom": "",
+            "value": null
+          }
+        }
+      ],
+      "type": "",
+      "extensionNameValue": []
+    }
+  ],
+  "wellLocation": [
+    {
+      "southing": {
+        "uom": "",
+        "value": null
+      },
+      "easting": {
+        "uom": "",
+        "value": null
+      },
+      "latitude": {
+        "uom": "",
+        "value": null
+      },
+      "description": "",
+      "extensionNameValue": [],
+      "northing": {
+        "uom": "",
+        "value": null
+      },
+      "uid": null,
+      "projectedX": {
+        "uom": "",
+        "value": null
+      },
+      "wellCRS": {
+        "value": "",
+        "uidRef": ""
+      },
+      "projectedY": {
+        "uom": "",
+        "value": null
+      },
+      "localY": {
+        "uom": "",
+        "value": null
+      },
+      "westing": {
+        "uom": "",
+        "value": null
+      },
+      "localX": {
+        "uom": "",
+        "value": null
+      },
+      "longitude": {
+        "uom": "",
+        "value": null
+      }
+    }
+  ],
+  "wellheadElevation": {
+    "datum": null,
+    "uom": null,
+    "value": null
+  },
+  "field": "",
+  "wellCRS": [
+    {
+      "uid": "",
+      "localCRS": {
+        "yaxisAzimuth": {
+          "uom": "",
+          "northDirection": null,
+          "value": null
+        },
+        "origin": {
+          "value": "",
+          "uidRef": null
+        },
+        "yaxisDescription": "",
+        "originDescription": ""
+      },
+      "geographic": {
+        "ztranslation": {
+          "uom": "",
+          "value": null
+        },
+        "xtranslation": {
+          "uom": "",
+          "value": null
+        },
+        "yrotation": {
+          "uom": "",
+          "value": null
+        },
+        "scaleFactor": null,
+        "ellipsoidCode": null,
+        "geodeticDatumCode": null,
+        "ellipsoidSemiMajorAxis": {
+          "uom": "",
+          "value": null
+        },
+        "ytranslation": {
+          "uom": "",
+          "value": null
+        },
+        "nameCRS": {
+          "namingSystem": "",
+          "code": "",
+          "value": ""
+        },
+        "ellipsoidInverseFlattening": null,
+        "xrotation": {
+          "uom": "",
+          "value": null
+        },
+        "zrotation": {
+          "uom": "",
+          "value": null
+        }
+      },
+      "mapProjection": {
+        "latitudeForScale": {
+          "uom": "",
+          "value": null
+        },
+        "originLatitude": {
+          "uom": "",
+          "value": null
+        },
+        "projectionCode": null,
+        "falseNorthing": {
+          "uom": "",
+          "value": null
+        },
+        "description": "",
+        "latitude1": {
+          "uom": "",
+          "value": null
+        },
+        "latitude2": {
+          "uom": "",
+          "value": null
+        },
+        "zone": "",
+        "parameter": [
+          {
+            "uid": null,
+            "uom": "",
+            "name": "",
+            "index": 0,
+            "description": "",
+            "value": ""
+          }
+        ],
+        "hemisphere": null,
+        "spheroidRadius": {
+          "uom": "",
+          "value": null
+        },
+        "longitudeForScale": {
+          "uom": "",
+          "value": null
+        },
+        "nadtype": null,
+        "stdParallel1": {
+          "uom": "",
+          "value": null
+        },
+        "trueScaleLatitude": {
+          "uom": "",
+          "value": null
+        },
+        "projectedFrom": {
+          "value": "",
+          "uidRef": ""
+        },
+        "perspectiveHeight": {
+          "uom": "",
+          "value": null
+        },
+        "bearing": {
+          "uom": "",
+          "value": null
+        },
+        "scaleFactor": null,
+        "centralMeridian": {
+          "uom": "",
+          "value": null
+        },
+        "methodVariant": null,
+        "stdParallel2": {
+          "uom": "",
+          "value": null
+        },
+        "longitude2": {
+          "uom": "",
+          "value": null
+        },
+        "longitude1": {
+          "uom": "",
+          "value": null
+        },
+        "originLongitude": {
+          "uom": "",
+          "value": null
+        },
+        "nameCRS": {
+          "namingSystem": "",
+          "code": "",
+          "value": ""
+        },
+        "falseEasting": {
+          "uom": "",
+          "value": null
+        }
+      },
+      "name": "",
+      "description": "",
+      "extensionNameValue": []
+    }
+  ],
+  "district": "",
+  "name": "",
+  "numGovt": "",
+  "region": "",
+  "wellDatum": [
+    {
+      "elevation": {
+        "datum": "",
+        "uom": null,
+        "value": null
+      },
+      "rig": {
+        "wellboreParent": {
+          "value": "",
+          "uidRef": null
+        },
+        "rigReference": {
+          "value": "",
+          "uidRef": null
+        },
+        "wellParent": {
+          "value": "",
+          "uidRef": null
+        }
+      },
+      "uid": "",
+      "wellbore": {
+        "wellParent": {
+          "value": "",
+          "uidRef": null
+        },
+        "wellboreReference": {
+          "value": "",
+          "uidRef": null
+        }
+      },
+      "datumName": {
+        "namingSystem": null,
+        "code": null,
+        "value": ""
+      },
+      "kind": [
+        ""
+      ],
+      "measuredDepth": {
+        "datum": "",
+        "uom": null,
+        "value": null
+      },
+      "name": "",
+      "comment": "",
+      "extensionNameValue": []
+    }
+  ]
+}

--- a/df-valve/src/test/resources/utilTest/well1311merged.json
+++ b/df-valve/src/test/resources/utilTest/well1311merged.json
@@ -1,0 +1,18 @@
+{
+  "country": "US",
+  "numLicense": "Company License Number",
+  "county": "Montgomery",
+  "operator": "Operating Company",
+  "objectType": "well",
+  "uid": "uid12333",
+  "nameLegal": "Company Legal Name",
+  "block": "Block Name",
+  "state": "TX",
+  "timeZone": "-06:00",
+  "version": "1.4.1.1",
+  "field": "FunctionalTest",
+  "district": "District Name",
+  "name": "Well hm1223",
+  "numGovt": "Govt-Number",
+  "region": "Region Name"
+}

--- a/df-valve/src/test/resources/utilTest/well1311src.json
+++ b/df-valve/src/test/resources/utilTest/well1311src.json
@@ -1,0 +1,24 @@
+{
+  "country": "US",
+  "numLicense": "Company License Number",
+  "commonData": {
+    "dTimLastChange": "2019-01-07T14:53:50.3274906+00:00",
+    "dTimCreation": "2019-01-03T16:34:23.924594+00:00"
+  },
+  "county": "Montgomery",
+  "timeZone": "-06:00",
+  "operator": "Operating Company",
+  "referencePoint": [],
+  "uid": "uid12333",
+  "wellLocation": [],
+  "field": "FunctionalTest",
+  "wellCRS": [],
+  "nameLegal": "Company Legal Name",
+  "district": "District Name",
+  "name": "Well hm1223",
+  "numGovt": "Govt-Number",
+  "block": "Block Name",
+  "state": "TX",
+  "region": "Region Name",
+  "wellDatum": []
+}


### PR DESCRIPTION
This PR includes:
- support for returning empty plural objects to clients when valid REST queries to DoT return 404 responses
- deep merging of nested complex JSONArray components in our util src/dest merging logic. A JSONArray used to be merged in if it was not "empty" (meaning []), but now "empty" is recursively inspected to ensure any array is considered empty if all of its sub elements are empty.
- testing to validate empty responses generate proper plural WITSML responses
- Util test suite and test json files to validate proper merging behavior for wells with nested JSONArray objects in the src object.

This connects to #218