### PR TITLE
df-228 -> implement hystrix for rest calls

### DIFF
--- a/df-valve/pom.xml
+++ b/df-valve/pom.xml
@@ -74,6 +74,11 @@
 			<artifactId>unirest-java</artifactId>
 			<version>1.4.9</version>
 		</dependency>
+		<dependency>
+			<groupId>com.netflix.hystrix</groupId>
+			<artifactId>hystrix-core</artifactId>
+			<version>1.5.18</version>
+		</dependency>
 
 		<!-- test dependencies -->
 		<dependency>

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotClient.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotClient.java
@@ -30,6 +30,7 @@ import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import com.mashape.unirest.request.HttpRequest;
+import com.mashape.unirest.request.HttpRequestWithBody;
 
 public class DotClient {
     private static final Logger LOG = Logger.getLogger(DotClient.class.getName());
@@ -65,12 +66,14 @@ public class DotClient {
             // build payload for authentication
             String payload = "{\"account\":\"" + username + "\", \"password\":\"" + password + "\"}";
 
+            // build request
+            HttpRequestWithBody req = Unirest.post(URL + this.TOKEN_PATH);
+            req.header("accept", "application/json")
+                .header("Ocp-Apim-Subscription-Key", this.API_KEY)
+                .body(payload);
+
             // send request
-            HttpResponse<String> response = Unirest.post(URL + this.TOKEN_PATH)
-                    .header("accept", "application/json")
-                    .header("Ocp-Apim-Subscription-Key", this.API_KEY)
-                    .body(payload)
-                    .asString();
+            HttpResponse<String> response = new DotRestCommand(req).run();
 
             // validate response
             int status = response.getStatus();
@@ -97,8 +100,8 @@ public class DotClient {
      * @throws ValveAuthException
      */
     public DecodedJWT getJWT(
-            String username,
-            String password
+        String username,
+        String password
     ) throws ValveAuthException {
         // refresh token if necessary
         if (!cache.containsKey(username) || isTokenExpired(username))

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotClient.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotClient.java
@@ -168,19 +168,21 @@ public class DotClient {
      * @param numRetries - number of times to retry when auth errors occur
      */
     private HttpResponse<String> makeRequest(
-            HttpRequest req,
-            String username,
-            String password,
-            int numRetries
-    ) throws UnirestException, ValveAuthException {
+        HttpRequest req,
+        String username,
+        String password,
+        int numRetries
+    ) throws UnirestException, ValveAuthException, ValveException {
         // get jwt
         String tokenString = this.getJWT(username, password).getToken();
 
-        LOG.info("Making request to " + req.getUrl());
         // execute request.
-        HttpResponse<String> response = req
-            .header("Authorization", "Bearer " + tokenString)
-            .asString();
+        req.header("Authorization", "Bearer " + tokenString); // add auth header
+        HttpResponse<String> response = new DotRestCommand(req).run();
+
+        // ensure response is not null
+        if (null == response)
+            throw new ValveException("Circuit broken for DoT REST requests");
 
         // check for auth errors.
         int status = response.getStatus();

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotRestCommand.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotRestCommand.java
@@ -1,0 +1,26 @@
+package com.hashmapinc.tempus.witsml.valve.dot;
+
+import com.mashape.unirest.http.exceptions.UnirestException;
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.request.HttpRequest;
+
+public class DotRestCommand extends HystrixCommand<HttpResponse<String>> {
+    private HttpRequest request;
+
+    /**
+     * builds a new rest command
+     * @param req - request to execute in run
+     */
+    public DotRestCommand(HttpRequest req) {
+        super(HystrixCommandGroupKey.Factory.asKey("DotValve"));
+        this.request = req;
+    }
+
+    @Override
+    protected HttpResponse<String> run() throws UnirestException {
+        return this.request.asString();
+    }
+}

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotRestCommand.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotRestCommand.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2018-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hashmapinc.tempus.witsml.valve.dot;
 
 import com.mashape.unirest.http.exceptions.UnirestException;

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotRestCommand.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotRestCommand.java
@@ -6,6 +6,7 @@ import com.netflix.hystrix.HystrixCommandGroupKey;
 
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.request.HttpRequest;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
 
 public class DotRestCommand extends HystrixCommand<HttpResponse<String>> {
     private HttpRequest request;
@@ -19,8 +20,25 @@ public class DotRestCommand extends HystrixCommand<HttpResponse<String>> {
         this.request = req;
     }
 
+    /**
+     * Hystrix run command for executing rest requests
+     *
+     * @return - response from executing the http request
+     * @throws UnirestException
+     */
     @Override
     protected HttpResponse<String> run() throws UnirestException {
         return this.request.asString();
+    }
+
+    /**
+     * This runs when an unexpected error occurs in run.
+     * Returning null informs the caller that Hystrix is
+     * preventing execution.
+     * @return null
+     */
+    @Override
+    protected HttpResponse<String> getFallback() {
+        return null; // fail silently
     }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
@@ -165,8 +165,8 @@ public class DotTranslator {
         if (0 == witsmlObjects.size()) {
             try {
                 xml = is1411 ?
-                    WitsmlMarshal.serialize(new com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbores()) :
-                    WitsmlMarshal.serialize(new com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbores());
+                    WitsmlMarshal.serialize(new com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbores()) :
+                    WitsmlMarshal.serialize(new com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbores());
             } catch (JAXBException jxbe) {
                 throw new ValveException("Could not serialize empty wellbores object");
             }

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotClientIT.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotClientIT.java
@@ -34,7 +34,7 @@ public class DotClientIT {
 		this.username = "admin";
 		this.password = "12345";
 		String apiKey = "test";
-		String url = "https://witsml.hashmapinc.com:8443/"; // TODO: MOCK THIS
+		String url = "https://witsml.hashmapinc.com:8443/";
 		String tokenPath = "token/jwt/v1/";
 		dotClient = new DotClient(url, apiKey, tokenPath);
 	}


### PR DESCRIPTION
This PR includes:
- creation of the DotRestCommand class for wrapping rest calls with the hystrix framework
- usage of the DotRestCommand.run() instead of direct Unirest execution throughout the code base.

This connects to #228