### PR TITLE
df-245: RTC can now create wellbores

### DIFF
--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -216,7 +216,7 @@ public class DotDelegator {
 
         // build the request
         HttpRequestWithBody request;
-        if (uid.isEmpty()){
+        if (null == uid || uid.isEmpty()){
             // create with POST and generate uid
             request = Unirest.post(endpoint);
         } else {
@@ -254,10 +254,10 @@ public class DotDelegator {
 			ValveLogging valveLoggingResponse = new ValveLogging(exchangeID,
 					logResponse(response, "Received successful status code from DoT create call"), witsmlObj);
 			LOG.info(valveLoggingResponse.toString());
-            return uid.isEmpty() ? new JsonNode(response.getBody()).getObject().getString("uid") : uid;
+            return (null == uid || uid.isEmpty()) ? new JsonNode(response.getBody()).getObject().getString("uid") : uid;
         } else {
 			ValveLogging valveLoggingResponse = new ValveLogging(exchangeID,
-					logResponse(response, "Received failure status code from DoT POST"), witsmlObj);
+					logResponse(response, "Received " + status + " from DoT POST" + response.getBody()), witsmlObj);
 			LOG.warning(valveLoggingResponse.toString());
             throw new ValveException(response.getBody());
         }


### PR DESCRIPTION
This resolves #245. 

RTC creates a wellbore without a UID, and it was causing the wellbore to be created, but the call would fail after succeeding in DoT because of how we check for UID's on the return.

There is now a null check before isEmpty, and this fixes the problem and RTC can create wellbores.