### PR TITLE
df-239: Common data is now returned

### DIFF
--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
@@ -17,6 +17,7 @@ package com.hashmapinc.tempus.witsml.valve.dot;
 
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.WitsmlObjects.Util.WitsmlMarshal;
+import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWell;
 import com.hashmapinc.tempus.witsml.valve.ValveException;
 import org.json.JSONObject;
 
@@ -86,6 +87,12 @@ public class DotTranslator {
         String objectType
     ) throws ValveException {
         // Merge the 2 objects
+        if (!query.has("commonData")){
+            query.append("commonData", new JSONObject());
+        }
+        JSONObject commonData = (JSONObject)query.get("commonData");
+        commonData.append("dTimLastChange", null);
+        commonData.append("dTimCreation", null);
         JSONObject result = Util.merge(query,response); // WARNING: this method modifies query internally
 
         // convert the queryJSON back to valid xml
@@ -93,9 +100,8 @@ public class DotTranslator {
         try {
             switch (objectType) { // TODO: support log and trajectory
                 case "well":
-                    return WitsmlMarshal.deserializeFromJSON(
-                        result.toString(), com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWell.class
-                    );
+                    ObjWell well =  WitsmlMarshal.deserializeFromJSON(result.toString(), com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWell.class);
+                    return well;
                 case "wellbore":
                     return WitsmlMarshal.deserializeFromJSON(
                         result.toString(), com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbore.class

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
@@ -100,7 +100,7 @@ public class DotTranslator {
         try {
             switch (objectType) { // TODO: support log and trajectory
                 case "well":
-                    ObjWell well =  WitsmlMarshal.deserializeFromJSON(result.toString(), com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWell.class);
+                    ObjWell well =  WitsmlMarshal.deserializeFromJSON(result.toString(), ObjWell.class);
                     return well;
                 case "wellbore":
                     return WitsmlMarshal.deserializeFromJSON(

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
 		<dependency>
 			<groupId>com.hashmapinc.tempus</groupId>
 			<artifactId>WitsmlObjects</artifactId>
-			<version>1.1.8</version>
+			<version>1.1.10</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
There was an issue where common data was not being returned, and Jackson was setting dTimLastChanged to dtimLastChanged and thus not ser/dser correctly. I have added the common data strings to always be returned in dotTranslator, and increased the version of the WOL for the serialization fix.