### PR TITLE
df-263: Converting to native trajectory converter

### DIFF
--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
@@ -16,6 +16,7 @@
 package com.hashmapinc.tempus.witsml.valve.dot;
 
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
+import com.hashmapinc.tempus.WitsmlObjects.Util.TrajectoryConverter;
 import com.hashmapinc.tempus.WitsmlObjects.Util.WellConverter;
 import com.hashmapinc.tempus.WitsmlObjects.Util.WellboreConverter;
 import com.hashmapinc.tempus.WitsmlObjects.Util.WitsmlMarshal;
@@ -65,10 +66,7 @@ public class DotTranslator {
                     return WellboreConverter.convertTo1311((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbore) obj1411);
                 case "trajectory":
                     if (obj1411 instanceof com.hashmapinc.tempus.WitsmlObjects.v1311.ObjTrajectory) return obj1411;
-                    String xml1311 = obj1411.getXMLString("1.3.1.1");
-                    return ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjTrajectorys) WitsmlMarshal.deserialize(
-                            xml1311, com.hashmapinc.tempus.WitsmlObjects.v1311.ObjTrajectorys.class)
-                    ).getTrajectory().get(0);
+                    return TrajectoryConverter.convertTo1311((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectory) obj1411);
                 default:
                     throw new ValveException("unsupported object type: " + obj1411.getObjectType());
             }

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
 		<dependency>
 			<groupId>com.hashmapinc.tempus</groupId>
 			<artifactId>WitsmlObjects</artifactId>
-			<version>1.1.15</version>
+			<version>1.1.16</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This PR resolves #263.

The Trajectory crud translator now uses the native converter to down-convert the 1411 response to 1311 when the query is performed in 1311.