### PR TITLE
df-269: fixing an issue where all of the elements of the trajectory object are not returned

### DIFF
--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/Util.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/Util.java
@@ -59,7 +59,7 @@ public class Util {
                 dest.put(key, destObj); // update dest with the updated value for this key
 
             } else if (destObj instanceof JSONArray && srcObj instanceof JSONArray ) {
-                if (!isEmpty(destObj) && !isEmpty(srcObj)) {
+                if (isEmpty(destObj) && !isEmpty(srcObj)) {
                     dest.put(key, srcObj); // TODO: deep merging on sub objects
                 }
             } else { // handle all basic values (non array, non nested objects)


### PR DESCRIPTION
This resolves #269 

Fixing an invalid check in the merge logic that resulted in arrays of complex objects not being merged.