### PR TITLE
Df-273: Fixing update query creation by removing empty fields

### DIFF
--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -168,6 +168,7 @@ public class DotDelegator {
 
 		// get witsmlObj as json string for request payload
 		String payload = witsmlObj.getJSONString("1.4.1.1");
+		payload = removeEmpties(payload);
 
 		// build the request
 		HttpRequestWithBody request = Unirest.put(endpoint);
@@ -206,6 +207,19 @@ public class DotDelegator {
 			LOG.warning(valveLoggingResponse.toString());
 			throw new ValveException(response.getBody());
 		}
+	}
+
+	private String removeEmpties(String jsonQuery){
+    	JSONObject object = new JSONObject(jsonQuery);
+    	ArrayList<String> keysToRemove = new ArrayList<>();
+    	for (Object key : object.keySet()){
+    		if (Util.isEmpty(object.get(key.toString())))
+    			keysToRemove.add(key.toString());
+		}
+    	for (String key : keysToRemove){
+    		object.remove(key);
+		}
+    	return object.toString();
 	}
 
     /**

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -27,7 +27,6 @@ import com.mashape.unirest.request.HttpRequest;
 import com.mashape.unirest.request.HttpRequestWithBody;
 import org.json.JSONObject;
 
-import javax.json.JsonObject;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -27,6 +27,7 @@ import com.mashape.unirest.request.HttpRequest;
 import com.mashape.unirest.request.HttpRequestWithBody;
 import org.json.JSONObject;
 
+import javax.json.JsonObject;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
@@ -168,7 +169,7 @@ public class DotDelegator {
 
 		// get witsmlObj as json string for request payload
 		String payload = witsmlObj.getJSONString("1.4.1.1");
-		payload = removeEmpties(payload);
+		payload = JsonUtil.removeEmpties(new JSONObject(payload));
 
 		// build the request
 		HttpRequestWithBody request = Unirest.put(endpoint);
@@ -207,19 +208,6 @@ public class DotDelegator {
 			LOG.warning(valveLoggingResponse.toString());
 			throw new ValveException(response.getBody());
 		}
-	}
-
-	private String removeEmpties(String jsonQuery){
-    	JSONObject object = new JSONObject(jsonQuery);
-    	ArrayList<String> keysToRemove = new ArrayList<>();
-    	for (Object key : object.keySet()){
-    		if (Util.isEmpty(object.get(key.toString())))
-    			keysToRemove.add(key.toString());
-		}
-    	for (String key : keysToRemove){
-    		object.remove(key);
-		}
-    	return object.toString();
 	}
 
     /**

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotTranslator.java
@@ -88,7 +88,7 @@ public class DotTranslator {
         String objectType
     ) throws ValveException {
         // Merge the 2 objects
-        JSONObject result = Util.merge(query,response); // WARNING: this method modifies query internally
+        JSONObject result = JsonUtil.merge(query,response); // WARNING: this method modifies query internally
 
         // convert the queryJSON back to valid xml
         LOG.info("Converting merged query JSON to valid XML string");

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/JsonUtil.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/JsonUtil.java
@@ -21,7 +21,7 @@ import java.util.Set;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-public class Util {
+public class JsonUtil {
 
     /**
      * This function merges the fields from src that
@@ -119,5 +119,22 @@ public class Util {
         }
 
         return false;
+    }
+
+    /**
+     * Checks for empty Json elements and removes them
+     * @param src the source JSON object that needs to have empty elements removed
+     * @return The resultant json string with no empty elements
+     */
+    public static String removeEmpties(JSONObject src){
+        ArrayList<String> keysToRemove = new ArrayList<>();
+        for (Object key : src.keySet()){
+            if (JsonUtil.isEmpty(src.get(key.toString())))
+                keysToRemove.add(key.toString());
+        }
+        for (String key : keysToRemove){
+            src.remove(key);
+        }
+        return src.toString();
     }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/Util.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/Util.java
@@ -83,7 +83,7 @@ public class Util {
      * @param obj - object to examine
      * @return boolean - true if emptiness is confirmed, else false
      */
-    private static boolean isEmpty(Object obj) {
+    public static boolean isEmpty(Object obj) {
         // handle nulls
         if (JSONObject.NULL.equals(obj)) return true;
 

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegatorTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegatorTest.java
@@ -25,7 +25,12 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWell;
+import org.json.JSONObject;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -65,6 +70,23 @@ public class DotDelegatorTest {
 
         // mock client
         this.client = mock(DotClient.class);
+    }
+
+    @Test
+    public void shouldCreateAnUpdateInStoreQueryWithoutEmptyArrays() throws Exception{
+        String query = TestUtilities.getResourceAsString("updateTest/WellCountryUpdate1311.xml");
+        ObjWells wells = WitsmlMarshal.deserialize(query, ObjWells.class);
+        ObjWell well = wells.getWell().get(0);
+        String expectedJson = TestUtilities.getResourceAsString("updateTest/WellCountryUpdateResult1311.json");
+
+        // get witsmlObj as json string for request payload
+        String payload = well.getJSONString("1.4.1.1");
+        payload = JsonUtil.removeEmpties(new JSONObject(payload));
+
+        ObjectMapper om = new ObjectMapper();
+        Map<String, Object> map1311 = (Map<String, Object>) (om.readValue(payload, Map.class));
+        Map<String, Object> expectedMap = (Map<String, Object>) (om.readValue(expectedJson, Map.class));
+        Assert.assertEquals(expectedMap, map1311);
     }
 
     @Test

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/JsonUtilTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/JsonUtilTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.reflect.Whitebox;
 
-public class UtilTest {
+public class JsonUtilTest {
 
     @Test
     public void shouldProperlyMerge1311Well() throws Exception {
@@ -35,7 +35,7 @@ public class UtilTest {
         JSONObject dest = new JSONObject(destString);
         JSONObject src = new JSONObject(srcString);
 
-        JSONObject merged = Util.merge(dest, src);
+        JSONObject merged = JsonUtil.merge(dest, src);
 
         String actual = merged.toString(2);
         String expected = new String(Files.readAllBytes(Paths.get("src/test/resources/utilTest/well1311merged.json")));
@@ -51,7 +51,7 @@ public class UtilTest {
 
         JSONObject dest = new JSONObject(destString);
         JSONObject src = new JSONObject(srcString);
-        JSONObject merged = Util.merge(dest, src);
+        JSONObject merged = JsonUtil.merge(dest, src);
 
         String actual = merged.toString(2);
         String expected = "{}";
@@ -61,7 +61,7 @@ public class UtilTest {
     
 	@Test
 	public void checkIsEmpty() throws Exception {
-		Util spy = PowerMockito.spy(new Util());
+		JsonUtil spy = PowerMockito.spy(new JsonUtil());
 		String methodToTest = "isEmpty";
 
 		String srcString = new String(Files.readAllBytes(Paths.get("src/test/resources/utilTest/well1311src.json")));

--- a/df-valve/src/test/resources/updateTest/WellCountryUpdate1311.xml
+++ b/df-valve/src/test/resources/updateTest/WellCountryUpdate1311.xml
@@ -1,0 +1,7 @@
+<wells xmlns="http://www.witsml.org/schemas/131" version="1.3.1.1">
+    <well  uid="wefwewefwe">
+        <name>Well xxxx</name>
+        <nameLegal>Company Legal Name</nameLegal>
+        <country>Mordor</country>
+    </well>
+</wells>

--- a/df-valve/src/test/resources/updateTest/WellCountryUpdateResult1311.json
+++ b/df-valve/src/test/resources/updateTest/WellCountryUpdateResult1311.json
@@ -1,0 +1,1 @@
+{"country":"Mordor","uid":"wefwewefwe","nameLegal":"Company Legal Name","name":"Well xxxx"}


### PR DESCRIPTION
This PR resolves #273

There was an issue when serializing an update query, that empty arrays would erroneously be sent and thus clearing DoT of any values in the complex object array. There is now a removeEmpties function in the JsonUtil class that will leverage the isEmpty method to remove those empty elements.

The Util Class has also been renamed to JsonUtil.