### PR TITLE
df-275: Creating the routing for element delete vs object delete

### DIFF
--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class DotDelegator {
+	public class DotDelegator {
     private static final Logger LOG = Logger.getLogger(DotDelegator.class.getName());
 
     private final String URL;
@@ -148,12 +148,6 @@ public class DotDelegator {
 			LOG.warning(valveLoggingResponse.toString());
             throw new ValveException("DELETE DoT REST call failed with status code: " + status);
         }
-    }
-
-    private boolean isObjectDelete(String dataObjectType, String data){
-        Pattern singularPattern = Pattern.compile("<([" + dataObjectType + "])[^<]*?/>");
-        Matcher m = singularPattern.matcher(data);
-        return m.find();
     }
 
     public void performElementDelete(AbstractWitsmlObject witsmlObj,

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -169,20 +169,9 @@ public class DotDelegator {
 									  String exchangeID,
 									  DotClient client
 	) throws ValveException, ValveAuthException, UnirestException {
-		String payload = witsmlObj.getJSONString("1.4.1.1");
-		JSONObject jsonObjPayload = new JSONObject(payload);
-		ArrayList<String> keysToRemove = new ArrayList<>();
-
-		for (Object key : jsonObjPayload.keySet()){
-			if (JsonUtil.isEmptyArray(jsonObjPayload.get(key.toString())))
-				keysToRemove.add(key.toString());
-		}
-		for (String key : keysToRemove){
-			jsonObjPayload.remove(key);
-		}
-		String revisedPayload = jsonObjPayload.toString();
-		revisedPayload = revisedPayload.replace("\"\"", "null");
-		performObjectUpdate(witsmlObj, username, password, revisedPayload, exchangeID, client);
+		// Throwing valve exception as this is currently not supported by DoT until the Patch API is implemented
+		// We dont want to delete the object because someone thought something was implemented.
+		throw new ValveException("Element delete not currently supported");
 	}
 
 	public void performObjectUpdate(AbstractWitsmlObject witsmlObj,
@@ -196,10 +185,6 @@ public class DotDelegator {
 		String uid = witsmlObj.getUid();
 		String objectType = witsmlObj.getObjectType();
 		String endpoint = this.getEndpoint(objectType) + uid;
-
-		// get witsmlObj as json string for request payload
-		//String payload = witsmlObj.getJSONString("1.4.1.1");
-		//payload = JsonUtil.removeEmpties(new JSONObject(payload));
 
 		// build the request
 		HttpRequestWithBody request = Unirest.put(endpoint);

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -229,7 +229,7 @@ public class DotValve implements IValve {
 	private boolean isObjectDelete(String dataObjectType, String data){
 		// This regex matches (for dataObjectType: well) <well uid="xxx" /> and <well uid="xxx"></well> and is multiline capable
 		Pattern singularPattern =
-				Pattern.compile("(<[" + dataObjectType + "][^<]*?/>)|<([" + dataObjectType + "][^<]*?></" + dataObjectType + ">)");
+				Pattern.compile("(<[" + dataObjectType + "][^<]*?/>)|<([" + dataObjectType + "][^<]*?>*[\\s\\S]</" + dataObjectType + ">)");
 		Matcher m = singularPattern.matcher(data);
 		return m.find();
 	}

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -206,7 +206,7 @@ public class DotValve implements IValve {
 
 			if (!isObjectDelete(wmlObject.getObjectType(), qc.QUERY_XML)){
 				// This is an element delete so re-route to delegator update
-				this.DELEGATOR.updateObjectForDelete(wmlObject, qc.USERNAME, qc.PASSWORD, qc.EXCHANGE_ID, this.CLIENT);
+				this.DELEGATOR.performElementDelete(wmlObject, qc.USERNAME, qc.PASSWORD, qc.EXCHANGE_ID, this.CLIENT);
 				result = true;
 			} else {
 				// This is an object delete, so straight delete

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.scheduling.annotation.Async;
@@ -191,16 +193,45 @@ public class DotValve implements IValve {
 	public CompletableFuture<Boolean> deleteObject(QueryContext qc) throws ValveException {
 		// delete each object with 1 retry for bad token errors
 		boolean result = false;
+		// According to the WITSML Spec you cannot delete more than one object (or sub elements of more than one object)
+		// at a time, so we do this check
+		if (qc.WITSML_OBJECTS.size() > 1)
+			throw new ValveException("Delete cannot have more than one singular object per query");
+		// This is rare but a check must be made
+		if (qc.WITSML_OBJECTS.size() == 0)
+			throw new ValveException("Delete must have exactly one singluar object, but found 0 in the query");
 		try {
-			for (AbstractWitsmlObject witsmlObject : qc.WITSML_OBJECTS) {
-				this.DELEGATOR.deleteObject(witsmlObject, qc.USERNAME, qc.PASSWORD, qc.EXCHANGE_ID, this.CLIENT);
+			// Should be a safe assumption as we check above
+			AbstractWitsmlObject wmlObject = qc.WITSML_OBJECTS.get(0);
+
+			if (!isObjectDelete(wmlObject.getObjectType(), qc.QUERY_XML)){
+				// This is an element delete so re-route to delegator update
+				this.DELEGATOR.updateObjectForDelete(wmlObject, qc.USERNAME, qc.PASSWORD, qc.EXCHANGE_ID, this.CLIENT);
+				result = true;
+			} else {
+				// This is an object delete, so straight delete
+				this.DELEGATOR.deleteObject(wmlObject, qc.USERNAME, qc.PASSWORD, qc.EXCHANGE_ID, this.CLIENT);
+				result = true;
 			}
-			result = true;
 		} catch (Exception e) {
 			LOG.warning("Got exception in DotValve delete object: " + e.getMessage());
 			throw new ValveException(e.getMessage());
 		}
 		return CompletableFuture.completedFuture(result);
+	}
+
+	/**
+	 * Determines if this delete is an element delete or object delete
+	 * @param dataObjectType they type of object to search for
+	 * @param data the WITSML query template document
+	 * @return True if it is an object delete, false if it is an element delete
+	 */
+	private boolean isObjectDelete(String dataObjectType, String data){
+		// This regex matches (for dataObjectType: well) <well uid="xxx" /> and <well uid="xxx"></well> and is multiline capable
+		Pattern singularPattern =
+				Pattern.compile("(<[" + dataObjectType + "][^<]*?/>)|<([" + dataObjectType + "][^<]*?></" + dataObjectType + ">)");
+		Matcher m = singularPattern.matcher(data);
+		return m.find();
 	}
 
 	/**

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/JsonUtil.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/JsonUtil.java
@@ -122,6 +122,22 @@ public class JsonUtil {
     }
 
     /**
+     * Checks to see if this JSONObject is an empty array. This is useful for checking if it should be
+     * serialized in a JSON output or not.
+     *
+     * @param obj The Object to examine
+     * @return boolean - true if is array AND empty, false if is not array or not empty
+     */
+    public static boolean isEmptyArray(Object obj){
+        // handle JSONArrays
+        if (obj instanceof JSONArray) {
+            return isEmpty(obj);
+        } else {
+            return false;
+        }
+    }
+
+    /**
      * Checks for empty Json elements and removes them
      * @param src the source JSON object that needs to have empty elements removed
      * @return The resultant json string with no empty elements

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegatorTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegatorTest.java
@@ -199,7 +199,6 @@ public class DotDelegatorTest {
         // build object
         ObjTrajectory traj = new ObjTrajectory();
         traj.setUid("traj-a");
-        traj.setName("traj-a");
         traj.setUidWellbore("wellbore-a");
         traj.setUidWell("well-a");
 

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -18,12 +18,10 @@ package com.hashmapinc.tempus.witsml.valve.dot;
 import com.auth0.jwt.JWT;
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.WitsmlObjects.Util.WitsmlMarshal;
-import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWell;
-import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbore;
-import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWells;
-import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjTrajectory;
+import com.hashmapinc.tempus.WitsmlObjects.v1311.*;
 import com.hashmapinc.tempus.witsml.QueryContext;
 import com.hashmapinc.tempus.witsml.valve.ValveAuthException;
+import com.hashmapinc.tempus.witsml.valve.ValveException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -294,11 +292,12 @@ public class DotValveTest {
 		// build witsmlObjects list
 		ArrayList<AbstractWitsmlObject> witsmlObjects;
 		witsmlObjects = new ArrayList<>();
+		ObjWellbores wmlObjWellbores = new ObjWellbores();
 
 		ObjWellbore wellboreA = new ObjWellbore();
-		wellboreA.setName("wellbore-A");
 		wellboreA.setUid("wellbore-A");
 		witsmlObjects.add(wellboreA);
+		wmlObjWellbores.addWellbore(wellboreA);
 
 
 		// build query context
@@ -306,7 +305,7 @@ public class DotValveTest {
 			"1.3.1.1",
 			"wellbore",
 			null,
-			"",
+			WitsmlMarshal.serialize(wmlObjWellbores),
 			witsmlObjects,
 			"goodUsername",
 			"goodPassword",
@@ -329,24 +328,27 @@ public class DotValveTest {
 		ArrayList<AbstractWitsmlObject> trajs1311 = new ArrayList<>();
 		ArrayList<AbstractWitsmlObject> trajs1411 = new ArrayList<>();
 
+		ObjTrajectorys trajsObj1311 = new ObjTrajectorys();
+		com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectorys trajsObj1411 = new com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectorys();
+
 		// get traj 1311
 		ObjTrajectory traj1311 = new ObjTrajectory();
-		traj1311.setName("traj-1311");
 		traj1311.setUid("traj-1311");
 		trajs1311.add(traj1311);
+		trajsObj1311.addTrajectory(traj1311);
 
 		// get traj 1411
 		com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectory traj1411 = new com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectory();
-		traj1411.setName("traj-1411");
 		traj1411.setUid("traj-1411");
 		trajs1411.add(traj1411);
+		trajsObj1411.addTrajectory(traj1411);
 
 		// build query contexts
 		QueryContext qc1311 = new QueryContext(
 			"1.3.1.1",
 			"trajectory",
 			null,
-			"",
+			WitsmlMarshal.serialize(trajsObj1311),
 			trajs1311,
 			"goodUsername",
 			"goodPassword",
@@ -356,7 +358,7 @@ public class DotValveTest {
 			"1.4.1.1",
 			"trajectory",
 			null,
-			"",
+				WitsmlMarshal.serialize(trajsObj1411),
 			trajs1411,
 			"goodUsername",
 			"goodPassword",
@@ -375,20 +377,22 @@ public class DotValveTest {
 		verifyNoMoreInteractions(this.mockDelegator);
 	}
 
-	@Test
-	public void shouldDeletePluralObject() throws Exception {
+	@Test(expected = ValveException.class)
+	public void shouldNotDeletePluralObjectAndThrowException() throws Exception {
 		// build witsmlObjects list
 		ArrayList<AbstractWitsmlObject> witsmlObjects;
 		witsmlObjects = new ArrayList<>();
 
+		ObjWellbores wmlObjWellbores = new ObjWellbores();
+
 		ObjWellbore wellboreA = new ObjWellbore();
-		wellboreA.setName("wellbore-A");
 		wellboreA.setUid("wellbore-A");
 		witsmlObjects.add(wellboreA);
+		wmlObjWellbores.addWellbore(wellboreA);
 
 		ObjWellbore wellboreB = new ObjWellbore();
-		wellboreB.setName("wellbore-B");
 		wellboreB.setUid("wellbore-B");
+		wmlObjWellbores.addWellbore(wellboreB);
 		witsmlObjects.add(wellboreB);
 
 
@@ -397,7 +401,7 @@ public class DotValveTest {
 			"1.3.1.1",
 			"wellbore",
 			null,
-			"",
+			WitsmlMarshal.serialize(wmlObjWellbores),
 			witsmlObjects,
 			"goodUsername",
 			"goodPassword",

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
 		<dependency>
 			<groupId>com.hashmapinc.tempus</groupId>
 			<artifactId>WitsmlObjects</artifactId>
-			<version>1.1.20</version>
+			<version>1.1.22</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This PR detects a DeleteFromStore request that is actually an element delete (meaning only deleting one tag of the xml document vs an entire object). It does this by executing a regex on the incoming XML. It was decided to read the query in vs serializing the AWO to avoid a separate and unnecessary serialization operation. The Regex will handle the following cases:

```xml
<object uid="x"></object> 
```
```xml
<object uid="x">
 </object>
```
```xml
<object uid="x" />
```
```xml
<object uid="x"/>
```

Currently this PR only detects the element deletion by the regex failing to find a match of any of the cases above and then routing that to _performElementDelete_ in _DotDelegator_. This function only throws a ValveException to say element delete is not supported. This is intended to avoid the unintentional delete of an entire object when a client expects to only delete an element.

 Additionally a method has been added in JsonUtil to detect empty JsonArrays. While this is not needed now, it will be needed once the Patch API is added to DoT. This is done to avoid the unintentional serialization of empty JsonArrays as we cannot use the _JsonInclude.NOT_EMPTY_ attribute as this would impact the merge logic during a GetFromStore procedure.