### PR TITLE
df-100: Upgrading the version of cxf

### DIFF
--- a/df-server/pom.xml
+++ b/df-server/pom.xml
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.2.6</version>
+            <version>3.2.8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.2.6</version>
+            <version>3.2.8</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>


### PR DESCRIPTION
This card resolves #100 by upgrading CXF which now leverages the module system of java 10+ and does not throw the scary warning about blocking reflection.