### PR TITLE
df-289: Removing the <return> element from the response

### DIFF
--- a/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/WitsmlApiConfig.java
+++ b/df-server/src/main/java/com/hashmapinc/tempus/witsml/server/WitsmlApiConfig.java
@@ -19,7 +19,10 @@ import javax.xml.ws.Endpoint;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.bus.spring.SpringBus;
+import org.apache.cxf.feature.transform.XSLTOutInterceptor;
+import org.apache.cxf.interceptor.StaxOutInterceptor;
 import org.apache.cxf.jaxws.EndpointImpl;
+import org.apache.cxf.phase.Phase;
 import org.apache.cxf.transport.common.gzip.GZIPOutInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,6 +34,8 @@ import com.hashmapinc.tempus.witsml.server.api.StoreImpl;
 
 @Configuration
 public class WitsmlApiConfig {
+
+    private final String XSLT_REQUEST_PATH = "interceptor/removeReturn.xsl";
 
     private Bus bus;
     private Environment env;
@@ -58,6 +63,12 @@ public class WitsmlApiConfig {
         EndpointImpl endpoint = new EndpointImpl(bus, storeImpl);
         if (compression)
             endpoint.getOutInterceptors().add(new GZIPOutInterceptor());
+
+        // Removes the <return> element that causes the certification test to fail
+        XSLTOutInterceptor returnRemoval = new XSLTOutInterceptor(Phase.PRE_STREAM, StaxOutInterceptor.class, null,
+                XSLT_REQUEST_PATH);
+        endpoint.getOutInterceptors().add(returnRemoval);
+
         endpoint.publish("/WMLS");
         return endpoint;
     }

--- a/df-server/src/main/resources/interceptor/removeReturn.xsl
+++ b/df-server/src/main/resources/interceptor/removeReturn.xsl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2018-2018 Hashmap, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:ns2="http://www.witsml.org/wsdl/120"
+                exclude-result-prefixes="ns2">
+    <xsl:output indent="yes" method="xml" />\
+    <xsl:template match="*">
+        <xsl:element name="{name()}" namespace="{namespace-uri()}">
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="return">
+        <xsl:apply-templates/>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
This resolves #289 

The certification test tool was returning a <return> element that was preventing it from running. It is implemented as an XSLTOutInterceptor as this was the mechanism that is least error prone and the least amount of code. 

After quite a lot of testing it was found that string manipulation was error prone, and the XSLT is not complex, as the return messages are never structurally that big (largest being 4 return elements). The largest part is a simple text() element that is copied over thus reducing overhead.