### PR TITLE
df-296: Fixing the merge logic

### DIFF
--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/JsonUtil.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/JsonUtil.java
@@ -42,6 +42,11 @@ public class JsonUtil {
         // iterate through keys and merge in place
         Set<String> keyset = dest.keySet();
         for (String key : keyset) {
+            // filter out empty arrays from the dest
+            if (isEmptyArray(dest.get(key))) {
+                keysToRemove.add(key);
+                continue;
+            }
             // check that the response has a value for this key.
             if (!src.has(key)) {
                 if (isEmpty(dest.get(key)))
@@ -131,10 +136,10 @@ public class JsonUtil {
     public static boolean isEmptyArray(Object obj){
         // handle JSONArrays
         if (obj instanceof JSONArray) {
-            return isEmpty(obj);
-        } else {
-            return false;
+            JSONArray arrObj = (JSONArray) obj;
+            return arrObj.length() == 0;
         }
+        return false;
     }
 
     /**


### PR DESCRIPTION
This PR resolves #296 

This removes the empty arrays that are not legal on a query.