### PR TITLE
df-305: Removing the colorized log output

### DIFF
--- a/df-server/src/main/resources/application.yml
+++ b/df-server/src/main/resources/application.yml
@@ -33,3 +33,5 @@ valve :
 wmls:
     version: 1.3.1.1,1.4.1.1
     compression: true
+logging:
+    config: ${LOGBACK_CONFIG_FILE:classpath:logback-spring.xml}

--- a/df-server/src/main/resources/logback-spring.xml
+++ b/df-server/src/main/resources/logback-spring.xml
@@ -24,7 +24,7 @@
               class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>
-                %black(%d{ISO8601}) %highlight(%-5level) [%blue(%t)] %yellow(%C{1.}): %msg%n%throwable
+                %d %p %C{1.} [%t] %m%n
             </Pattern>
         </layout>
     </appender>

--- a/df-server/src/main/resources/logback-spring.xml
+++ b/df-server/src/main/resources/logback-spring.xml
@@ -24,7 +24,7 @@
               class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>
-                %d %p %C{1.} [%t] %m%n
+                ${CONSOLE_LOGGER_PATTERN:-%d %p %C{1.} [%t] %m%n}
             </Pattern>
         </layout>
     </appender>

--- a/df-server/src/main/resources/logback-spring.xml
+++ b/df-server/src/main/resources/logback-spring.xml
@@ -34,7 +34,7 @@
         <file>${LOGS}/spring-boot-logger.log</file>
         <encoder
                 class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
+            <Pattern>${FILE_LOGGER_PATTERN:-%d %p %C{1.} [%t] %m%n}</Pattern>
         </encoder>
 
         <rollingPolicy
@@ -44,7 +44,7 @@
             </fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy
                     class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>10MB</maxFileSize>
+                <maxFileSize>${FILE_LOGGER_MAX_SIZE:-10MB}</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
     </appender>

--- a/docs/source/integration/index.rst
+++ b/docs/source/integration/index.rst
@@ -12,3 +12,4 @@ These guides will help you integrate the WITSML Server API with your API impleme
    witsml_ver
    capabilities
    returnmsg
+   logging

--- a/docs/source/integration/logging.rst
+++ b/docs/source/integration/logging.rst
@@ -1,0 +1,81 @@
+##################
+Setting up Logging
+##################
+
+This guide documents how to configure logging in Drillflow.
+
+************
+Introduction
+************
+
+Drillflow uses logback-spring.xml to configure logging. The default logging configuration can be seen here on GitHub.
+`here on GitHub <https://github.com/hashmapinc/Drillflow/blob/master/df-server/src/main/resources/logback-spring.xml/>`_.
+
+A tutorial on how to modify this file can be found here: `logback.xml Example <https://www.mkyong.com/logging/logback-xml-example/>`_
+
+This default configuration has 2 appenders, a console appender and a file appender. There are several parts of the file
+that have been made configurable via environment variables to facilitate running in a container.
+
+If you would like to configure it more deeply (as in adding additional appenders, or changing the logging functionality
+overall, you will want to skip to externalizing the configuration.
+
+***********************
+Configurable Properties
+***********************
+
+In the default logback-spring.xml the following items are configurable via environment variables:
+
+:Variable:
+    LOGBACK_CONFIG_FILE
+:Description:
+    The path to the logback configuration file to use. This could be mounted from a volume
+:Default:
+    %d %p %C{1.} [%t] %m%n
+:Example Environmental Switch in Docker:
+    To Colorize: -e LOGBACK_CONFIG_FILE='/mnt/config/logback-spring.xml'
+
+:Variable:
+    CONSOLE_LOGGER_PATTERN
+:Description:
+    The pattern to use when logging to the console.
+:Default:
+    %d %p %C{1.} [%t] %m%n
+:Example Environmental Switch in Docker:
+    To Colorize: -e CONSOLE_LOGGER_PATTERN='%black(%d{ISO8601}) %highlight(%-5level) [%blue(%t)] %yellow(%C{1.}): %msg%n%throwable'
+
+:Variable:
+    FILE_LOGGER_PATTERN
+:Description:
+    The pattern to use when logging to a file.
+:Default:
+    %d %p %C{1.} [%t] %m%n
+:Example Environmental Switch in Docker:
+    Simplified output: -e CONSOLE_LOGGER_PATTERN='%d{yyyy-MM-dd HH:mm:ss} - %msg%n'
+
+:Variable:
+    FILE_LOGGER_MAX_SIZE
+:Default:
+    10MB
+:Example Environmental Switch in Docker:
+    To increase size: -e FILE_LOGGER_MAX_SIZE='20MB'
+
+:Variable:
+    LOGS
+:Description:
+    The root for a logs directory. It is suggested to log to a mounted volume.
+:Example Environmental Switch in Docker:
+    To increase size: -e FILE_LOGGER_MAX_SIZE='20MB'
+
+Example Docker *run* Command to Set multiple properties:
+
+``
+docker run -p 7070:7070 -e VALVE_BASE_URL='https://test.com/' -e VALVE_API_KEY='secret' -e CONSOLE_LOGGER_PATTERN='%black(%d{ISO8601}) %highlight(%-5level) [%blue(%t)] %yellow(%C{1.}): %msg%n%throwable' hashmapinc/drillflow:latest
+``
+
+**********************
+External Configuration
+**********************
+
+The configuration could be mounted externally via a docker volume that is mapped to the container internally.
+This is ideal for the case when you would want to centralize a common logging configuration across many containers. You would
+leverage the *LOGBACK_CONFIG_FILE* as mentioned above.


### PR DESCRIPTION
This PR resolves #305.

This PR removes the colorized log output as requested, for ease of logging. The rolling file appender is still there however, not sure why that is not used.

This connects #327 for the documentation portion