### PR TITLE
df-337 -> add uuid/uid caching support

### DIFF
--- a/df-server/src/test/java/com/hashmapinc/tempus/witsml/server/api/AsyncTest.java
+++ b/df-server/src/test/java/com/hashmapinc/tempus/witsml/server/api/AsyncTest.java
@@ -35,7 +35,7 @@ import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbore;
 import com.hashmapinc.tempus.witsml.QueryContext;
 import com.hashmapinc.tempus.witsml.server.AsyncAppConstants;
 import com.hashmapinc.tempus.witsml.server.WitsmlServerApplication;
-import com.hashmapinc.tempus.witsml.valve.dot.DotClient;
+import com.hashmapinc.tempus.witsml.valve.dot.client.DotClient;
 import com.hashmapinc.tempus.witsml.valve.dot.DotDelegator;
 import com.hashmapinc.tempus.witsml.valve.dot.DotValve;
 

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -20,6 +20,9 @@ import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectory;
 import com.hashmapinc.tempus.witsml.ValveLogging;
 import com.hashmapinc.tempus.witsml.valve.ValveAuthException;
 import com.hashmapinc.tempus.witsml.valve.ValveException;
+import com.hashmapinc.tempus.witsml.valve.dot.client.DotClient;
+import com.hashmapinc.tempus.witsml.valve.dot.graphql.GraphQLQueryConverter;
+import com.hashmapinc.tempus.witsml.valve.dot.graphql.GraphQLRespConverter;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
@@ -158,11 +161,12 @@ public class DotDelegator {
         }
     }
 
-    public void performElementDelete(AbstractWitsmlObject witsmlObj,
-									 String username,
-									 String password,
-									 String exchangeID,
-									 DotClient client
+    public void performElementDelete(
+		AbstractWitsmlObject witsmlObj,
+		String username,
+		String password,
+		String exchangeID,
+		DotClient client
 	) throws ValveException, ValveAuthException, UnirestException {
 		// Throwing valve exception as this is currently not supported by DoT until the Patch API is implemented
 		// We dont want to delete the object because someone thought something was implemented.
@@ -199,15 +203,15 @@ public class DotDelegator {
 		int status = response.getStatus();
 		if (201 == status || 200 == status || 204 == status) {
 			LOG.info(ValveLogging.getLogMsg(
-					exchangeID,
-					logResponse(response, "Successfully Patched Object with UID :"+uid+"."),
-					witsmlObj)
+				exchangeID,
+				logResponse(response, "Successfully Patched Object with UID :"+uid+"."),
+				witsmlObj)
 			);
 		} else {
 			LOG.warning(ValveLogging.getLogMsg(
-					exchangeID,
-					logResponse(response, "Unable to patch"),
-					witsmlObj)
+				exchangeID,
+				logResponse(response, "Unable to patch"),
+				witsmlObj)
 			);
 			throw new ValveException("PATCH DoT REST call failed with status code: " + status);
 		}

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -218,13 +218,12 @@ public class DotDelegator {
 	}
 
 	public void updateObject(
-			AbstractWitsmlObject witsmlObj,
-			String username,
-			String password,
-			String exchangeID,
-			DotClient client
+		AbstractWitsmlObject witsmlObj,
+		String username,
+		String password,
+		String exchangeID,
+		DotClient client
 	) throws ValveException, ValveAuthException, UnirestException {
-
 		String uid = witsmlObj.getUid();
 		String objectType = witsmlObj.getObjectType();
 		String endpoint = this.getEndpoint(objectType) + uid;
@@ -245,6 +244,7 @@ public class DotDelegator {
 			request.queryString("uidWellbore", witsmlObj.getParentUid());
 			String uidWell;
 			if ("1.4.1.1".equals(witsmlObj.getVersion())) {
+				// TODO: maybe replace with this -> uidWell = witsmlObj.getGrandParentUid();
 				uidWell = ((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectory) witsmlObj).getUidWell();
 			} else {
 				uidWell = ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjTrajectory) witsmlObj).getUidWell();
@@ -511,12 +511,12 @@ public class DotDelegator {
 	}
 
 	private String getWellboreUUID(
-			AbstractWitsmlObject wmlObject,
-			String exchangeID,
-			DotClient client,
-			String username,
-			String password)
-			throws ValveException, ValveAuthException, UnirestException {
+		AbstractWitsmlObject wmlObject,
+		String exchangeID,
+		DotClient client,
+		String username,
+		String password
+	) throws ValveException, ValveAuthException, UnirestException {
 
 		String endpoint = this.getEndpoint( "wellboresearch");
 

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.hashmapinc.tempus.witsml.valve.dot.client.DotClient;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.scheduling.annotation.Async;
 

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/DotClient.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/DotClient.java
@@ -58,8 +58,8 @@ public class DotClient {
      * @param password
      */
     private void refreshToken(
-            String username,
-            String password
+        String username,
+        String password
     ) throws ValveAuthException {
         try {
             // build payload for authentication

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/DotClient.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/DotClient.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hashmapinc.tempus.witsml.valve.dot;
+package com.hashmapinc.tempus.witsml.valve.dot.client;
 
 import java.util.Date;
 import java.util.HashMap;

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/DotRestCommand.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/DotRestCommand.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hashmapinc.tempus.witsml.valve.dot;
+package com.hashmapinc.tempus.witsml.valve.dot.client;
 
 import com.mashape.unirest.http.exceptions.UnirestException;
 import com.netflix.hystrix.HystrixCommand;

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/UidUuidCache.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/UidUuidCache.java
@@ -40,8 +40,8 @@ public class UidUuidCache {
      * @param uid - string uid used as a cache value
      */
     public static void putInCache(
-            String uuid,
-            String uid
+        String uuid,
+        String uid
     ) {
         // store 2-way mappings in cache
         cache.put(uuid, uid); // uuid->uid mapping

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/UidUuidCache.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/UidUuidCache.java
@@ -1,0 +1,174 @@
+package com.hashmapinc.tempus.witsml.valve.dot.client;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This cache stores mappings between uid/uuid pairs. The same
+ * hashmap is used for uid->uuid and for uuid->uid.
+ *
+ * There are 3 types of objects supported in this map:
+ * 1: parentless objects with no parent uid
+ * 2: objects with a single parent, but no grandparent
+ * 3: objects with a parent and a grandparent, but no more
+ *
+ * UUID values always map directly to a uid string. However, uid's
+ * are only guaranteed to be unique within a same parent. Therefore,
+ * to ensure no uid->uuid collisions, composite keys must be used to map
+ * to UUID values.
+ *
+ * The composite keys for each supported object case is:
+ * 1: parentless objects use "object_uid" as the key
+ * 2: single parent objects use "parent_uid|===|object_uid" as the key
+ * 3: single grandparent objects use "grandparent_uid|===|parent_uid|===|object_uid" as the key
+ *
+ * each composite key points directly to a UUID string.
+ *
+ * This class can be easily update to support external caching (like REDIS) by replacing
+ * the concurrent hashmap with calls to an external service.
+ */
+public class UidUuidCache {
+    // cache used for uid->uuid AND uuid->uid mapping
+    private static ConcurrentHashMap<String, String> cache = new ConcurrentHashMap<>();
+    private static final String SEPARATOR = "|===|"; // separator used when building composite keys
+
+    /**
+     * This function stores a mapping between a uid and uuid.
+     *
+     * This function is used for parentless objects
+     *
+     * @param uuid - string uuid used as a cache key
+     * @param uid - string uid used as a cache value
+     */
+    public static void putInCache(
+            String uuid,
+            String uid
+    ) {
+        // store 2-way mappings in cache
+        cache.put(uuid, uid); // uuid->uid mapping
+        cache.put(uid, uuid); // uid->uuid mapping
+    }
+
+    /**
+     * This function stores a mapping between a uid and uuid.
+     *
+     * This function is used for parent-only objects
+     *
+     * @param uuid - string uuid to cache
+     * @param uid - string uid to cache
+     * @param parentUid - string uid of the parent object needed for
+     *                  building the composite key
+     */
+    public static void putInCache(
+        String uuid,
+        String uid,
+        String parentUid
+    ) {
+        // build composite key
+        String compositeKey = parentUid + SEPARATOR + uid;
+
+        // store 2-way mappings in cache
+        cache.put(uuid, uid);         // uuid->uid
+        cache.put(compositeKey, uid); // uid->uuid
+    }
+
+    /**
+     * This function stores a mapping between a uid and uuid.
+     *
+     * This function is used for grandparent-only objects
+     *
+     * @param uuid - string uuid to cache
+     * @param uid - string uid to cache
+     * @param parentUid - string uid of the parent object needed for
+     *                    building the composite key
+     * @param grandparentUid - string uid of the grandparent object needed
+     *                         for building the composite key
+     */
+    public static void putInCache(
+        String uuid,
+        String uid,
+        String parentUid,
+        String grandparentUid
+    ) {
+        // build composite key
+        String compositeKey = grandparentUid + SEPARATOR + parentUid + SEPARATOR + uid;
+
+        // store 2-way mappings in cache
+        cache.put(uuid, uid);         // uuid->uid
+        cache.put(compositeKey, uid); // uid->uuid
+    }
+
+    /**
+     * This function checks the cache for a matching uid.
+     *
+     * If a match is found, it is returned.
+     *
+     * @param uuid - string value of the uuid to use for uid lookup
+     * @return - uid String found mapped to the given uuid.
+     */
+    public static String getUid(String uuid) {
+        // check cache
+        if (cache.containsKey(uuid))
+            return cache.get(uuid);
+
+        return null; // no match found
+    }
+
+    /**
+     * returns the uuid for a parentless object with given uid.
+     *
+     * @param uid - string identifier for the object uuid being requested
+     * @return - uuid string if a uuid can be found, otherwise null is returned
+     */
+    public static String getUuid(String uid) {
+        // check cache
+        if (cache.containsKey(uid))
+            return cache.get(uid);
+
+        return null; // no match found
+    }
+
+    /**
+     * returns the uuid for a grandparent-only object with
+     * the given uid and parentUid.
+     *
+     * @param uid - string identifier for the object uuid being requested
+     * @param parentUid - string uid of the parent of the object UUID being requested
+     * @return - uuid string if a uuid can be found, otherwise null is returned
+     */
+    public static String getUuid(
+        String uid,
+        String parentUid
+    ) {
+        // build composite key
+        String compositeKey = parentUid + SEPARATOR + uid;
+
+        // check cache
+        if (cache.containsKey(compositeKey))
+            return cache.get(compositeKey);
+
+        return null; // no match found
+    }
+
+    /**
+     * returns the uuid for a grandparent-only object with
+     * the given uid, parentUid, and grandparentUid.
+     *
+     * @param uid - string identifier for the object uuid being requested
+     * @param parentUid - string uid of the parent of the object UUID being requested
+     * @return - uuid string if a uuid can be found, otherwise null is returned
+     */
+    public static String getUuid(
+        String uid,
+        String parentUid,
+        String grandparentUid
+    ) {
+        // build composite key
+        String compositeKey = grandparentUid + SEPARATOR + parentUid + SEPARATOR + uid;
+
+        // check cache
+        if (cache.containsKey(compositeKey))
+            return cache.get(compositeKey);
+
+        return null; // no match found
+    }
+}

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/UidUuidCache.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/UidUuidCache.java
@@ -67,8 +67,8 @@ public class UidUuidCache {
         String compositeKey = parentUid + SEPARATOR + uid;
 
         // store 2-way mappings in cache
-        cache.put(uuid, uid);         // uuid->uid
-        cache.put(compositeKey, uid); // uid->uuid
+        cache.put(uuid, uid);          // uuid->uid
+        cache.put(compositeKey, uuid); // uid->uuid
     }
 
     /**
@@ -93,8 +93,8 @@ public class UidUuidCache {
         String compositeKey = grandparentUid + SEPARATOR + parentUid + SEPARATOR + uid;
 
         // store 2-way mappings in cache
-        cache.put(uuid, uid);         // uuid->uid
-        cache.put(compositeKey, uid); // uid->uuid
+        cache.put(uuid, uid);          // uuid->uid
+        cache.put(compositeKey, uuid); // uid->uuid
     }
 
     /**

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/UidUuidCache.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/UidUuidCache.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2018-2019 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hashmapinc.tempus.witsml.valve.dot.client;
 
 import java.util.concurrent.ConcurrentHashMap;

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLQueryConstants.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLQueryConstants.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hashmapinc.tempus.witsml.valve.dot;
+package com.hashmapinc.tempus.witsml.valve.dot.graphql;
 
 public class GraphQLQueryConstants {
     //=========================================================================

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLQueryConstants.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLQueryConstants.java
@@ -793,7 +793,7 @@ public class GraphQLQueryConstants {
     // WELLBORE UID UUID MAPPING QUERY
     //=========================================================================
 
-    public static final String WELLBORE_UID_MAPPING_QUERY =
+    public static final String WELLBORE_AND_WELL_UUID_QUERY =
             "query WellboreQuery($arg: WellboreArgument) {\n" +
                     "  wellbores(wellboreArgument: $arg) {\n" +
                     "    uuid\n" +

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLQueryConverter.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLQueryConverter.java
@@ -13,16 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hashmapinc.tempus.witsml.valve.dot;
+package com.hashmapinc.tempus.witsml.valve.dot.graphql;
 
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
+import com.hashmapinc.tempus.witsml.valve.dot.JsonUtil;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.IOException;
 
 //This class takes a WITSML Query search and converts it to a GraphQL search
-class GraphQLQueryConverter {
+public class GraphQLQueryConverter {
 
     /**
      * Converts a WITSML search query to GraphQL
@@ -227,7 +228,6 @@ class GraphQLQueryConverter {
 
         // return payload
         return payload.toString(2);
-
     }
 
     private static String createWellboreQuery(String jsonObj) {

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLQueryConverter.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLQueryConverter.java
@@ -43,8 +43,8 @@ public class GraphQLQueryConverter {
         }
     }
 
-    public static String getQuery(AbstractWitsmlObject wmlObject, String uuid){
-        return getTrajectoryQuery(wmlObject, uuid);
+    public static String getQuery(AbstractWitsmlObject wmlObject, String wellboreUuid){
+        return getTrajectoryQuery(wmlObject, wellboreUuid);
     }
 
     /**
@@ -199,32 +199,39 @@ public class GraphQLQueryConverter {
         return payload.toString(2);
     }
 
-    public static String getUidUUIDMappingQuery(AbstractWitsmlObject wmlObject){
+    /**
+     * This function accepts any wmlObject that has a
+     * wellbore parent and a well grandparent and builds
+     * a graphql query to get the uuid's of the well/wellbore.
+     *
+     * @param wmlObject - log or trajectory object child to query with
+     * @return - graphQL query string needed to get well/wellbore uuids
+     */
+    public static String getWellboreAndWellUuidQuery(AbstractWitsmlObject wmlObject){
         JSONObject payload = new JSONObject();
 
         // parse json strings
         String jsonString1411 = wmlObject.getJSONString("1.4.1.1");
         JSONObject wmlObjJson = new JSONObject(jsonString1411);
 
-        // ====================================================================
-        // get trajectory query fields
-        // ====================================================================
-        JSONObject wellQueryFields = new JSONObject();
-        // uidWellbore
-        if (wmlObjJson.has("uidWellbore") && !JsonUtil.isEmpty(wmlObjJson.get("uidWellbore")))
-            wellQueryFields.put("uid", wmlObjJson.get("uidWellbore"));
 
-        // uidWell
+        // get query fields from the wmlObjJson
+        JSONObject queryFields = new JSONObject();
+
+        if (wmlObjJson.has("uidWellbore") && !JsonUtil.isEmpty(wmlObjJson.get("uidWellbore")))
+            queryFields.put("uid", wmlObjJson.get("uidWellbore")); // add wellbore uid to query fields
+
         if (wmlObjJson.has("uidWell") && !JsonUtil.isEmpty(wmlObjJson.get("uidWell")))
-            wellQueryFields.put("uidWell", wmlObjJson.get("uidWell"));
+            queryFields.put("uidWell", wmlObjJson.get("uidWell")); // add well uid to query fields
+
 
         // build variables section
         JSONObject variables = new JSONObject();
-        variables.put("arg", wellQueryFields);
+        variables.put("arg", queryFields);
         payload.put("variables", variables);
 
         // build query section of payload
-        payload.put("query", GraphQLQueryConstants.WELLBORE_UID_MAPPING_QUERY);
+        payload.put("query", GraphQLQueryConstants.WELLBORE_AND_WELL_UUID_QUERY);
 
         // return payload
         return payload.toString(2);

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLRespConverter.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLRespConverter.java
@@ -120,7 +120,13 @@ public class GraphQLRespConverter {
         return foundObjects;
     }
 
-    public static String getUUid(JSONObject response){
+    /**
+     * This function accepts the JSONObject 2.0 wtsml
+     * representation of either a
+     * @param response
+     * @return
+     */
+    public static String get(JSONObject response){
         if (!response.has("data"))
             return null;
 

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLRespConverter.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLRespConverter.java
@@ -121,17 +121,16 @@ public class GraphQLRespConverter {
     }
 
     public static String getUUid(JSONObject response){
-        if (!response.has("data")){
+        if (!response.has("data"))
             return null;
-        }
+
         JSONObject data = (JSONObject)response.get("data");
-        if (!data.has("wellbores")){
+        if (!data.has("wellbores"))
             return null;
-        }
         if (data.get("wellbores") == null)
             return null;
-        JSONArray wells = (JSONArray) data.get("wellbores");
 
+        JSONArray wells = (JSONArray) data.get("wellbores");
         return ((JSONObject)wells.get(0)).getString("uuid");
     }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLRespConverter.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLRespConverter.java
@@ -121,22 +121,24 @@ public class GraphQLRespConverter {
     }
 
     /**
-     * This function accepts the JSONObject 2.0 wtsml
-     * representation of either a
+     * This function accepts the JSONObject wellbore graphql response
+     * representation and extracts the wellbore's UUID
      * @param response
      * @return
      */
-    public static String get(JSONObject response){
+    public static String getWellboreUuidFromGraphqlResponse(JSONObject response){
+        // check that the response has data
         if (!response.has("data"))
             return null;
 
-        JSONObject data = (JSONObject)response.get("data");
+        // check that wellbores exist in the response
+        JSONObject data = response.getJSONObject("data");
         if (!data.has("wellbores"))
             return null;
         if (data.get("wellbores") == null)
             return null;
 
-        JSONArray wells = (JSONArray) data.get("wellbores");
-        return ((JSONObject)wells.get(0)).getString("uuid");
+        // return the uuid of the first wellbore in the response.
+        return data.getJSONArray("wellbores").getJSONObject(0).getString("uuid");
     }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLRespConverter.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLRespConverter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hashmapinc.tempus.witsml.valve.dot;
+package com.hashmapinc.tempus.witsml.valve.dot.graphql;
 
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.WitsmlObjects.Util.TrajectoryConverter;

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegatorTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegatorTest.java
@@ -29,8 +29,8 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWell;
-import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectorys;
-import org.hamcrest.CoreMatchers;
+import com.hashmapinc.tempus.witsml.valve.dot.client.DotClient;
+import com.hashmapinc.tempus.witsml.valve.dot.graphql.GraphQLQueryConverter;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Before;

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/DotValveTest.java
@@ -22,6 +22,7 @@ import com.hashmapinc.tempus.WitsmlObjects.v1311.*;
 import com.hashmapinc.tempus.witsml.QueryContext;
 import com.hashmapinc.tempus.witsml.valve.ValveAuthException;
 import com.hashmapinc.tempus.witsml.valve.ValveException;
+import com.hashmapinc.tempus.witsml.valve.dot.client.DotClient;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/client/UidUuidCacheTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/client/UidUuidCacheTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright © 2018-2019 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hashmapinc.tempus.witsml.valve.dot.client;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class UidUuidCacheTest {
+    @Test
+    public void shouldCacheParentlessObjects() {
+        // set test values
+        String uid = "cool_uid_A";
+        String uuid = "cool_uuid_A";
+
+        // assert null responses
+        assertNull(UidUuidCache.getUuid(uid));
+        assertNull(UidUuidCache.getUid(uuid));
+
+        // cache data
+        UidUuidCache.putInCache(uuid, uid);
+
+        // assert responses match
+        assertEquals(uid, UidUuidCache.getUid(uuid));
+        assertEquals(uuid, UidUuidCache.getUuid(uid));
+    }
+
+    @Test
+    public void shouldCacheParentOnlyObjects() {
+        // set test values
+        String uid = "cool_uid_B";
+        String parentUid = "cool_parent_uid_B";
+        String uuid = "cool_uuid_B";
+
+        // assert null responses
+        assertNull(UidUuidCache.getUuid(uid, parentUid));
+        assertNull(UidUuidCache.getUid(uuid));
+
+        // cache data
+        UidUuidCache.putInCache(uuid, uid, parentUid);
+
+        // assert responses match
+        assertEquals(uid, UidUuidCache.getUid(uuid));
+        assertEquals(uuid, UidUuidCache.getUuid(uid, parentUid));
+    }
+
+    @Test
+    public void shouldCacheGrandprentOnlyObjects() {
+        // set test values
+        String uid = "cool_uid_C";
+        String parentUid = "cool_parent_uid_C";
+        String grandparentUid = "cool_grandparent_uid_C";
+        String uuid = "cool_uuid_C";
+
+        // assert null responses
+        assertNull(UidUuidCache.getUuid(uid, parentUid, grandparentUid));
+        assertNull(UidUuidCache.getUid(uuid));
+
+        // cache data
+        UidUuidCache.putInCache(uuid, uid, parentUid, grandparentUid);
+
+        // assert responses match
+        assertEquals(uid, UidUuidCache.getUid(uuid));
+        assertEquals(uuid, UidUuidCache.getUuid(uid, parentUid, grandparentUid));
+    }
+}

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLQueryConverterTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLQueryConverterTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hashmapinc.tempus.witsml.valve.dot;
+package com.hashmapinc.tempus.witsml.valve.dot.graphql;
 
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.WitsmlObjects.Util.WitsmlMarshal;
@@ -21,6 +21,9 @@ import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectory;
 import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectorys;
 import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbore;
 import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbores;
+import com.hashmapinc.tempus.witsml.valve.dot.TestUtilities;
+import com.hashmapinc.tempus.witsml.valve.dot.graphql.GraphQLQueryConverter;
+import com.hashmapinc.tempus.witsml.valve.dot.graphql.GraphQLRespConverter;
 import org.junit.Test;
 
 import java.util.List;

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLQueryConverterTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLQueryConverterTest.java
@@ -22,8 +22,6 @@ import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectorys;
 import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbore;
 import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbores;
 import com.hashmapinc.tempus.witsml.valve.dot.TestUtilities;
-import com.hashmapinc.tempus.witsml.valve.dot.graphql.GraphQLQueryConverter;
-import com.hashmapinc.tempus.witsml.valve.dot.graphql.GraphQLRespConverter;
 import org.junit.Test;
 
 import java.util.List;

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLQueryConverterTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/graphql/GraphQLQueryConverterTest.java
@@ -66,8 +66,7 @@ public class GraphQLQueryConverterTest {
     public void generateProperGraphQLQueryUUIDUidMapping() throws Exception {
         String queryXML = TestUtilities.getResourceAsString("trajectoryGraphql/trajectoryGraphqlQuery1411.xml");
         ObjTrajectory obj = ((ObjTrajectorys) WitsmlMarshal.deserialize(queryXML, ObjTrajectorys.class)).getTrajectory().get(0);
-        GraphQLQueryConverter converter = new GraphQLQueryConverter();
-        String graphQLQuery = converter.getUidUUIDMappingQuery(obj);
+        String graphQLQuery = GraphQLQueryConverter.getWellboreAndWellUuidQuery(obj);
         assertNotNull(graphQLQuery);
         assertTrue(graphQLQuery.contains("\"arg\": {\n" +
                 "    \"uid\": \"uidWellbore\",\n" +


### PR DESCRIPTION
This PR includes:
- organization of the dot package into 2 new subpackages
- addition of the UidUuidCache class for uid/uuid mapping with a local concurrent hashmap inside the DF container.
- test cases for the cache
- general syntax / format tidying, particularly on variable/function naming.

This connects to #337 