### PR TITLE
Df-339: Modify JUnit test for Df-298 Building a static graphql query

### DIFF
--- a/df-server/src/test/java/com/hashmapinc/tempus/witsml/server/api/AsyncTest.java
+++ b/df-server/src/test/java/com/hashmapinc/tempus/witsml/server/api/AsyncTest.java
@@ -15,13 +15,14 @@
  */
 package com.hashmapinc.tempus.witsml.server.api;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.concurrent.CompletableFuture;
-
+import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
+import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbore;
+import com.hashmapinc.tempus.witsml.QueryContext;
+import com.hashmapinc.tempus.witsml.server.AsyncAppConstants;
+import com.hashmapinc.tempus.witsml.server.WitsmlServerApplication;
+import com.hashmapinc.tempus.witsml.valve.dot.DotDelegator;
+import com.hashmapinc.tempus.witsml.valve.dot.DotValve;
+import com.hashmapinc.tempus.witsml.valve.dot.client.DotClient;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.annotation.Bean;
@@ -30,14 +31,12 @@ import org.springframework.context.annotation.Import;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
-import com.hashmapinc.tempus.WitsmlObjects.v1311.ObjWellbore;
-import com.hashmapinc.tempus.witsml.QueryContext;
-import com.hashmapinc.tempus.witsml.server.AsyncAppConstants;
-import com.hashmapinc.tempus.witsml.server.WitsmlServerApplication;
-import com.hashmapinc.tempus.witsml.valve.dot.client.DotClient;
-import com.hashmapinc.tempus.witsml.valve.dot.DotDelegator;
-import com.hashmapinc.tempus.witsml.valve.dot.DotValve;
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class AsyncTest {
 

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/GraphQLQueryConverterTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/GraphQLQueryConverterTest.java
@@ -15,30 +15,89 @@
  */
 package com.hashmapinc.tempus.witsml.valve.dot;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hashmapinc.tempus.WitsmlObjects.AbstractWitsmlObject;
 import com.hashmapinc.tempus.WitsmlObjects.Util.WitsmlMarshal;
 import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectory;
 import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjTrajectorys;
 import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbore;
 import com.hashmapinc.tempus.WitsmlObjects.v1411.ObjWellbores;
+import org.json.JSONObject;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 public class GraphQLQueryConverterTest {
 
     @Test
     public void generateProperGraphQLQueryForWellbore() throws Exception {
-        String query = TestUtilities.getResourceAsString("wellboreOpenQuery1411.xml");
-        ObjWellbores queryObject = WitsmlMarshal.deserialize(query, ObjWellbores.class);
+        final String variablesNodeName = "variables";
+        final String queryNodeName = "query";
+        final String wellboreArgNodeName = "wellboreArgument";
+        final String wellboreOpenQuery = "wellboreOpenQuery1411.xml";
+        JSONObject wellboreQueryFields = new JSONObject();
+
+        // Get what is expected from the resource...
+        String queryString = TestUtilities.getResourceAsString(wellboreOpenQuery);
+        ObjWellbores queryObject = WitsmlMarshal.deserialize(queryString, ObjWellbores.class);
         ObjWellbore singularObject = queryObject.getWellbore().get(0);
+        JSONObject wellboreJson = new JSONObject(singularObject.getJSONString("1.4.1.1"));
+
+        // Get what the code-under-test produces...
         GraphQLQueryConverter converter = new GraphQLQueryConverter();
         String graphQLQuery = converter.getQuery(singularObject);
+
+        // Perform the tests...
+
+        // 1st: check that the query was produced...
         assertNotNull(graphQLQuery);
-        //  assertTrue(graphQLQuery.contains("title"));
+
+        // 2nd: Check if the produced JSON contains all of the populated query fields
+        //      from the Resource and build wellbore query fields dynamically ...
+        checkNbuildQuery("uid", wellboreJson, graphQLQuery, wellboreQueryFields );
+        checkNbuildQuery("uidWell", wellboreJson, graphQLQuery, wellboreQueryFields );
+        checkNbuildQuery("name", wellboreJson, graphQLQuery, wellboreQueryFields );
+        checkNbuildQuery("nameWell", wellboreJson, graphQLQuery, wellboreQueryFields );
+
+        // 3rd: Create comparable object (to perform an apples-to-apples comparison) & then
+        //      perform a deep comparison of the json values...
+        JSONObject comparable = new JSONObject();
+        comparable.put( queryNodeName, GraphQLQueryConstants.WELLBORE_QUERY );
+
+        // build variables section
+        JSONObject variables = new JSONObject();
+        variables.put( wellboreArgNodeName, wellboreQueryFields );
+        comparable.put( variablesNodeName, variables );
+        String comparableToString = comparable.toString(2);
+
+        ObjectMapper om = new ObjectMapper();
+        Map<String, Object> producedMap = (Map<String, Object>) (om.readValue(graphQLQuery, Map.class));
+        Map<String, Object> expectedMap = (Map<String, Object>) (om.readValue(comparableToString, Map.class));
+        assertEquals( producedMap, expectedMap );
+
+    }
+
+    /* ******************************************************************************* */
+    /* checkNbuildQuery verifies that if the resource object contains the query field, */
+    /* then the produced JSON also contains that query field.                          */
+    /* ******************************************************************************* */
+    private static void checkNbuildQuery(String queryField,
+                                         JSONObject resourceObj,
+                                         String producedJson,
+                                         JSONObject wellboreQueryFields )
+    {
+
+        if ( resourceObj.has(queryField) && !JsonUtil.isEmpty(resourceObj.get(queryField))  ) {
+            assertTrue( producedJson.contains(queryField) );
+            assertTrue( producedJson.contains(resourceObj.getString(queryField)) );
+            wellboreQueryFields.put(queryField, resourceObj.get(queryField));
+        }
+
     }
 
     @Test


### PR DESCRIPTION
This PR resolves #339.

1. Create an object from the test utility's "wellboreOpenQuery" resource that is comparable to the one created by the code-under-test. As with the tested code, dynamically check how to build the correct query fields within this object.
2. Get the code-under-test's open query object, and compare it to the one just created using the test utility's resource. Perform a deep comparison of the JSON values.