### PR TITLE
df-423: adding equivalence checks for channel and channelset

### DIFF
--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -421,13 +421,13 @@ public class DotDelegator {
 					List<Channel> chanList = Channel
 							.from1411((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog) witsmlObj);
 					channelPayload = Channel.channelListToJson(chanList);
+					data = DotLogDataHelper.convertDataToDot((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog)witsmlObj);
 				} else {
 					channelSetPayload = ChannelSet
 							.from1311((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog) witsmlObj).toJson();
 					List<Channel> chanList = Channel
 							.from1311((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog) witsmlObj);
 					channelPayload = Channel.channelListToJson(chanList);
-					data = DotLogDataHelper.convertDataToWitsml20((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog)witsmlObj);
 				}
 			} catch (JsonProcessingException e) {
 				throw new ValveException("Error converting Log to ChannelSet");

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotDelegator.java
@@ -421,7 +421,7 @@ public class DotDelegator {
 					List<Channel> chanList = Channel
 							.from1411((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog) witsmlObj);
 					channelPayload = Channel.channelListToJson(chanList);
-					data = DotLogDataHelper.convertDataToDot((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog)witsmlObj);
+					data = DotLogDataHelper.convertDataToDot((ObjLog)witsmlObj);
 				} else {
 					channelSetPayload = ChannelSet
 							.from1311((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog) witsmlObj).toJson();

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channel/AxisDefinition.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channel/AxisDefinition.java
@@ -15,10 +15,7 @@
  */
 package com.hashmapinc.tempus.witsml.valve.dot.model.log.channel;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -307,4 +304,24 @@ public class AxisDefinition {
         return wmlAxes;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AxisDefinition that = (AxisDefinition) o;
+        return Objects.equals(axisStart, that.axisStart) &&
+                Objects.equals(axisSpacing, that.axisSpacing) &&
+                Objects.equals(axisCount, that.axisCount) &&
+                Objects.equals(axisName, that.axisName) &&
+                Objects.equals(axisUom, that.axisUom) &&
+                Objects.equals(uid, that.uid) &&
+                Objects.equals(order, that.order) &&
+                Objects.equals(doubleValues, that.doubleValues) &&
+                Objects.equals(stringValues, that.stringValues);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(axisStart, axisSpacing, axisCount, axisName, axisUom, uid, order, doubleValues, stringValues);
+    }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channel/Channel.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channel/Channel.java
@@ -874,4 +874,53 @@ public class Channel {
 
         return xmlGregCal;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Channel channel = (Channel) o;
+        return Objects.equals(uuid, channel.uuid) &&
+                Objects.equals(uid, channel.uid) &&
+                Objects.equals(wellDatum, channel.wellDatum) &&
+                Objects.equals(nullValue, channel.nullValue) &&
+                Objects.equals(channelState, channel.channelState) &&
+                Objects.equals(classIndex, channel.classIndex) &&
+                Objects.equals(mnemAlias, channel.mnemAlias) &&
+                Objects.equals(alternateIndex, channel.alternateIndex) &&
+                Objects.equals(sensorOffset, channel.sensorOffset) &&
+                Objects.equals(densData, channel.densData) &&
+                Objects.equals(traceOrigin, channel.traceOrigin) &&
+                Objects.equals(traceState, channel.traceState) &&
+                Objects.equals(namingSystem, channel.namingSystem) &&
+                Objects.equals(mnemonic, channel.mnemonic) &&
+                Objects.equals(dataType, channel.dataType) &&
+                Objects.equals(description, channel.description) &&
+                Objects.equals(uom, channel.uom) &&
+                Objects.equals(source, channel.source) &&
+                Objects.equals(axisDefinition, channel.axisDefinition) &&
+                Objects.equals(timeDepth, channel.timeDepth) &&
+                Objects.equals(channelClass, channel.channelClass) &&
+                Objects.equals(classWitsml, channel.classWitsml) &&
+                Objects.equals(runNumber, channel.runNumber) &&
+                Objects.equals(passNumber, channel.passNumber) &&
+                Objects.equals(loggingCompanyName, channel.loggingCompanyName) &&
+                Objects.equals(loggingCompanyCode, channel.loggingCompanyCode) &&
+                Objects.equals(toolName, channel.toolName) &&
+                Objects.equals(toolClass, channel.toolClass) &&
+                Objects.equals(derivation, channel.derivation) &&
+                Objects.equals(loggingMethod, channel.loggingMethod) &&
+                Objects.equals(nominalHoleSize, channel.nominalHoleSize) &&
+                Objects.equals(index, channel.index) &&
+                Objects.equals(aliases, channel.aliases) &&
+                Objects.equals(citation, channel.citation) &&
+                Objects.equals(customData, channel.customData) &&
+                Objects.equals(objectVersion, channel.objectVersion) &&
+                Objects.equals(existenceKind, channel.existenceKind);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uuid, uid, wellDatum, nullValue, channelState, classIndex, mnemAlias, alternateIndex, sensorOffset, densData, traceOrigin, traceState, namingSystem, mnemonic, dataType, description, uom, source, axisDefinition, timeDepth, channelClass, classWitsml, runNumber, passNumber, loggingCompanyName, loggingCompanyCode, toolName, toolClass, derivation, loggingMethod, nominalHoleSize, index, aliases, citation, customData, objectVersion, existenceKind);
+    }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channel/DensData.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channel/DensData.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -106,4 +107,17 @@ public class DensData {
         return wmlDensData;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DensData densData = (DensData) o;
+        return Objects.equals(uom, densData.uom) &&
+                Objects.equals(value, densData.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uom, value);
+    }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channel/MnemAlias.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channel/MnemAlias.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -95,4 +96,17 @@ public class MnemAlias {
         return alias;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MnemAlias mnemAlias = (MnemAlias) o;
+        return Objects.equals(namingSystem, mnemAlias.namingSystem) &&
+                Objects.equals(value, mnemAlias.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(namingSystem, value);
+    }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channel/SensorOffset.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channel/SensorOffset.java
@@ -18,6 +18,7 @@ package com.hashmapinc.tempus.witsml.valve.dot.model.log.channel;
 import com.fasterxml.jackson.annotation.*;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -105,4 +106,17 @@ public class SensorOffset {
         return wmlOffset;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SensorOffset that = (SensorOffset) o;
+        return Objects.equals(uom, that.uom) &&
+                Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uom, value);
+    }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channel/WellDatum.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channel/WellDatum.java
@@ -18,6 +18,7 @@ package com.hashmapinc.tempus.witsml.valve.dot.model.log.channel;
 import com.fasterxml.jackson.annotation.*;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -103,5 +104,19 @@ public class WellDatum {
         wmlDatum.setUidRef(wellDatum.getUidRef());
         wmlDatum.setValue(wellDatum.getValue());
         return wmlDatum;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WellDatum wellDatum = (WellDatum) o;
+        return Objects.equals(uidRef, wellDatum.uidRef) &&
+                Objects.equals(value, wellDatum.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uidRef, value);
     }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/AcquisitionTimeZone.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/AcquisitionTimeZone.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -64,4 +65,17 @@ public class AcquisitionTimeZone {
         this.additionalProperties.put(name, value);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AcquisitionTimeZone that = (AcquisitionTimeZone) o;
+        return Objects.equals(dTim, that.dTim) &&
+                Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dTim, value);
+    }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/ChannelSet.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/ChannelSet.java
@@ -493,6 +493,51 @@ public class ChannelSet {
         this.wellId = wellId;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ChannelSet that = (ChannelSet) o;
+        return Objects.equals(uuid, that.uuid) &&
+                Objects.equals(bhaRunNumber, that.bhaRunNumber) &&
+                Objects.equals(aliases, that.aliases) &&
+                Objects.equals(citation, that.citation) &&
+                Objects.equals(customData, that.customData) &&
+                Objects.equals(objectVersion, that.objectVersion) &&
+                Objects.equals(index, that.index) &&
+                Objects.equals(dataUpateRate, that.dataUpateRate) &&
+                Objects.equals(curveSensorsAligned, that.curveSensorsAligned) &&
+                Objects.equals(dataGroup, that.dataGroup) &&
+                Objects.equals(stepIncrement, that.stepIncrement) &&
+                Objects.equals(logParam, that.logParam) &&
+                Objects.equals(dataDelimiter, that.dataDelimiter) &&
+                Objects.equals(nullValue, that.nullValue) &&
+                Objects.equals(channelState, that.channelState) &&
+                Objects.equals(timeDepth, that.timeDepth) &&
+                Objects.equals(channelClass, that.channelClass) &&
+                Objects.equals(runNumber, that.runNumber) &&
+                Objects.equals(passNumber, that.passNumber) &&
+                Objects.equals(loggingCompanyName, that.loggingCompanyName) &&
+                Objects.equals(loggingCompanyCode, that.loggingCompanyCode) &&
+                Objects.equals(toolName, that.toolName) &&
+                Objects.equals(toolClass, that.toolClass) &&
+                Objects.equals(derivation, that.derivation) &&
+                Objects.equals(loggingMethod, that.loggingMethod) &&
+                Objects.equals(nominalHoleSize, that.nominalHoleSize) &&
+                Objects.equals(dataContext, that.dataContext) &&
+                Objects.equals(commonData, that.commonData) &&
+                Objects.equals(uid, that.uid) &&
+                Objects.equals(uidWell, that.uidWell) &&
+                Objects.equals(uidWellbore, that.uidWellbore) &&
+                Objects.equals(wellId, that.wellId) &&
+                Objects.equals(wellboreId, that.wellboreId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uuid, bhaRunNumber, aliases, citation, customData, objectVersion, index, dataUpateRate, curveSensorsAligned, dataGroup, stepIncrement, logParam, dataDelimiter, nullValue, channelState, timeDepth, channelClass, runNumber, passNumber, loggingCompanyName, loggingCompanyCode, toolName, toolClass, derivation, loggingMethod, nominalHoleSize, dataContext, commonData, uid, uidWell, uidWellbore, wellId, wellboreId);
+    }
+
     @JsonProperty("wellboreId")
     public String getWellboreId() {
         return wellboreId;
@@ -525,6 +570,8 @@ public class ChannelSet {
         Citation citation = new Citation();
         citation.setTitle(witsmlObj.getName());
         citation.setDescription(witsmlObj.getDescription());
+        if (witsmlObj.getCreationDate() != null)
+            citation.setCreation(witsmlObj.getCreationDate().toXMLFormat());
         cs.setCitation(citation);
         cs.setBhaRunNumber(witsmlObj.getBhaRunNumber());
         cs.setDataGroup(witsmlObj.getDataGroup());

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/Citation.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/Citation.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -155,4 +156,21 @@ public class Citation {
         this.additionalProperties.put(name, value);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Citation citation = (Citation) o;
+        return Objects.equals(title, citation.title) &&
+                Objects.equals(format, citation.format) &&
+                Objects.equals(editor, citation.editor) &&
+                Objects.equals(versionString, citation.versionString) &&
+                Objects.equals(description, citation.description) &&
+                Objects.equals(descriptiveKeywords, citation.descriptiveKeywords);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(title, format, editor, versionString, description, descriptiveKeywords);
+    }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/CommonData.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/CommonData.java
@@ -18,10 +18,7 @@ package com.hashmapinc.tempus.witsml.valve.dot.model.log.channelset;
 import com.fasterxml.jackson.annotation.*;
 import com.hashmapinc.tempus.WitsmlObjects.v1411.TimestampedTimeZone;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -228,5 +225,26 @@ public class CommonData {
         }
         
         return cd;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CommonData that = (CommonData) o;
+        return Objects.equals(itemState, that.itemState) &&
+                Objects.equals(serviceCategory, that.serviceCategory) &&
+                Objects.equals(comments, that.comments) &&
+                Objects.equals(acquisitionTimeZone, that.acquisitionTimeZone) &&
+                Objects.equals(defaultDatum, that.defaultDatum) &&
+                Objects.equals(privateGroupOnly, that.privateGroupOnly) &&
+                Objects.equals(extensionAny, that.extensionAny) &&
+                Objects.equals(dTimCreation, that.dTimCreation) &&
+                Objects.equals(dTimLastChange, that.dTimLastChange);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(itemState, serviceCategory, comments, acquisitionTimeZone, defaultDatum, privateGroupOnly, extensionAny, dTimCreation, dTimLastChange);
     }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/DefaultDatum.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/DefaultDatum.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -64,4 +65,17 @@ public class DefaultDatum {
         this.additionalProperties.put(name, value);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DefaultDatum that = (DefaultDatum) o;
+        return Objects.equals(uidRef, that.uidRef) &&
+                Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uidRef, value);
+    }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/ExtensionNameValue.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/ExtensionNameValue.java
@@ -234,4 +234,24 @@ public class ExtensionNameValue {
 
         return xmlGregCal;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExtensionNameValue that = (ExtensionNameValue) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(value, that.value) &&
+                Objects.equals(measureClass, that.measureClass) &&
+                Objects.equals(index, that.index) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(dataType, that.dataType) &&
+                Objects.equals(md, that.md) &&
+                Objects.equals(uid, that.uid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, value, measureClass, index, description, dataType, md, uid);
+    }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/Index.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/Index.java
@@ -17,11 +17,7 @@ package com.hashmapinc.tempus.witsml.valve.dot.model.log.channelset;
 
 import com.fasterxml.jackson.annotation.*;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -151,4 +147,20 @@ public class Index {
         return indices;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Index index = (Index) o;
+        return Objects.equals(indexType, index.indexType) &&
+                Objects.equals(uom, index.uom) &&
+                Objects.equals(direction, index.direction) &&
+                Objects.equals(mnemonic, index.mnemonic) &&
+                Objects.equals(datumReference, index.datumReference);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(indexType, uom, direction, mnemonic);
+    }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/LogParam.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/LogParam.java
@@ -17,10 +17,7 @@ package com.hashmapinc.tempus.witsml.valve.dot.model.log.channelset;
 
 import com.fasterxml.jackson.annotation.*;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -66,6 +63,24 @@ public class LogParam {
     @JsonProperty("name")
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LogParam logParam = (LogParam) o;
+        return Objects.equals(index, logParam.index) &&
+                Objects.equals(name, logParam.name) &&
+                Objects.equals(uom, logParam.uom) &&
+                Objects.equals(description, logParam.description) &&
+                Objects.equals(uid, logParam.uid) &&
+                Objects.equals(value, logParam.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, name, uom, description, uid, value);
     }
 
     @JsonProperty("uom")

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/Md.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/Md.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -101,4 +102,18 @@ public class Md {
         return wmlMd;  
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Md md = (Md) o;
+        return Objects.equals(uom, md.uom) &&
+                Objects.equals(value, md.value) &&
+                Objects.equals(datum, md.datum);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uom, value, datum);
+    }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/StepIncrement.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/StepIncrement.java
@@ -17,6 +17,7 @@ package com.hashmapinc.tempus.witsml.valve.dot.model.log.channelset;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -145,4 +146,19 @@ public class StepIncrement {
         return wmlInc;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StepIncrement that = (StepIncrement) o;
+        return Objects.equals(uom, that.uom) &&
+                Objects.equals(value, that.value) &&
+                Objects.equals(numerator, that.numerator) &&
+                Objects.equals(denominator, that.denominator);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uom, value, numerator, denominator);
+    }
 }

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/Value.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channelset/Value.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -64,4 +65,17 @@ public class Value {
         this.additionalProperties.put(name, value);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Value value1 = (Value) o;
+        return Objects.equals(uom, value1.uom) &&
+                Objects.equals(value, value1.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uom, value);
+    }
 }

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/ChannelSetConversionTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/ChannelSetConversionTest.java
@@ -15,19 +15,15 @@
  */
 package com.hashmapinc.tempus.witsml.valve.dot.model.log;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.io.IOException;
-
-import javax.xml.bind.JAXBException;
-
 import com.hashmapinc.tempus.WitsmlObjects.Util.WitsmlMarshal;
-import com.hashmapinc.tempus.WitsmlObjects.v1411.IndexedObject;
 import com.hashmapinc.tempus.witsml.valve.dot.TestUtilities;
 import com.hashmapinc.tempus.witsml.valve.dot.model.log.channelset.ChannelSet;
-
 import org.junit.Test;
+
+import javax.xml.bind.JAXBException;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
 
 public class ChannelSetConversionTest {
     @Test

--- a/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/ChannelSetConversionTest.java
+++ b/df-valve/src/test/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/ChannelSetConversionTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright © 2018-2019 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hashmapinc.tempus.witsml.valve.dot.model.log;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+
+import javax.xml.bind.JAXBException;
+
+import com.hashmapinc.tempus.WitsmlObjects.Util.WitsmlMarshal;
+import com.hashmapinc.tempus.WitsmlObjects.v1411.IndexedObject;
+import com.hashmapinc.tempus.witsml.valve.dot.TestUtilities;
+import com.hashmapinc.tempus.witsml.valve.dot.model.log.channelset.ChannelSet;
+
+import org.junit.Test;
+
+public class ChannelSetConversionTest {
+    @Test
+    public void shouldCovertChannelSetFrom1411() throws JAXBException, IOException {
+        String logXml = TestUtilities.getResourceAsString("log1411.xml");
+        com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLogs logs = 
+            WitsmlMarshal.deserialize(logXml, com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLogs.class);
+        
+        com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog log = logs.getLog().get(0);
+        ChannelSet channelSet = ChannelSet.from1411(log);
+        assertEquals(log.getName(), channelSet.getCitation().getTitle());
+        assertEquals(log.getServiceCompany(), channelSet.getLoggingCompanyName());
+        assertEquals(log.getRunNumber(), channelSet.getRunNumber());
+        assertEquals(log.getCreationDate().toString(), channelSet.getCitation().getCreation());
+        assertEquals(log.getDescription(), channelSet.getCitation().getDescription());
+        //assertEquals(log.getIndexType(), channelSet.getTimeDepth());
+        assertEquals(log.getStartIndex().getValue().toString(), channelSet.getStartIndex());
+        assertEquals(log.getEndIndex().getValue().toString(), channelSet.getEndIndex());
+        assertEquals(log.getStepIncrement().getUom(), channelSet.getStepIncrement().getUom());
+        assertEquals(log.getStepIncrement().getValue().toString(), channelSet.getStepIncrement().getValue());
+        assertEquals(log.getNullValue(), channelSet.getNullValue());
+        for (int i = 0; i < log.getLogParam().size(); i++){
+            assertEquals(log.getLogParam().get(i).getDescription(),
+                    channelSet.getLogParam().get(i).getDescription());
+            assertEquals(log.getLogParam().get(i).getIndex(),
+                    channelSet.getLogParam().get(i).getIndex());
+            assertEquals(log.getLogParam().get(i).getName(),
+                    channelSet.getLogParam().get(i).getName());
+            assertEquals(log.getLogParam().get(i).getUom(),
+                    channelSet.getLogParam().get(i).getUom());
+            assertEquals(log.getLogParam().get(i).getUid(),
+                    channelSet.getLogParam().get(i).getUid());
+            assertEquals(log.getLogParam().get(i).getValue(),
+                    channelSet.getLogParam().get(i).getValue());
+        }
+        assertEquals(log.getCommonData().getItemState(), channelSet.getCommonData().getItemState());
+        assertEquals(log.getCommonData().getComments(), channelSet.getCommonData().getComments());
+    }
+}

--- a/df-valve/src/test/resources/dotConversion/log1411.xml
+++ b/df-valve/src/test/resources/dotConversion/log1411.xml
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="utf-16"?>
+<logs xmlns="http://www.witsml.org/schemas/1series" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.witsml.org/schemas/1series  ../xsd_schemas/obj_log.xsd" version="1.4.1.1">
+  <log uidWell="uid12335" uidWellbore="2f74b464-c789-4cfb-a508-f31e2fdd31ad" uid="Traj-1234">
+    <nameWell>6507/7-A-42_2</nameWell>
+    <nameWellbore>Wellbore hashmaptrajtest</nameWellbore>
+    <name>0002</name>
+    <serviceCompany>Baker Hughes INTEQ</serviceCompany>
+    <runNumber>12</runNumber>
+    <creationDate>2001-06-18T13:20:00.000Z</creationDate>
+    <description>Drilling Data Log</description>
+    <indexType>measured depth</indexType>
+    <startIndex uom="m">499</startIndex>
+    <endIndex uom="m">509.01</endIndex>
+    <stepIncrement uom="m">0</stepIncrement>
+    <direction>increasing</direction>
+    <indexCurve>Mdepth</indexCurve>
+    <nullValue>-999.25</nullValue>
+    <logParam index="1" name="MRES" uom="ohm.m" description="Mud Resistivity" uid="lp-1">1.25</logParam>
+    <logParam index="2" name="BDIA" uom="in" description="Bit Diameter" uid="lp-2">12.25</logParam>
+    <logCurveInfo uid="lci-1">
+      <mnemonic>Mdepth</mnemonic>
+      <classWitsml>measured depth of hole</classWitsml>
+      <unit>m</unit>
+      <mnemAlias>md</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Measured depth</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-2">
+      <mnemonic>Vdepth</mnemonic>
+      <classWitsml>TVD of hole</classWitsml>
+      <unit>m</unit>
+      <mnemAlias>tvd</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Vertical depth</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-3">
+      <mnemonic>Bit Dist</mnemonic>
+      <classWitsml>measured depth of DST bottom</classWitsml>
+      <unit>m</unit>
+      <mnemAlias>distBit</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Distance drilled by bit</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-4">
+      <mnemonic>TQ on btm</mnemonic>
+      <classWitsml>torque (average)</classWitsml>
+      <unit>kft.lbf</unit>
+      <mnemAlias>tqOnBot</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>On bottom torque</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-5">
+      <mnemonic>TQ off btm</mnemonic>
+      <classWitsml>torque (average)</classWitsml>
+      <unit>kft.lbf</unit>
+      <mnemAlias>toOffBot</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Off bottom torque</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-6">
+      <mnemonic>ROP</mnemonic>
+      <classWitsml>rate of penetration (average)</classWitsml>
+      <unit>m/h</unit>
+      <mnemAlias>ropAv</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Drill rate</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-7">
+      <mnemonic>WOP</mnemonic>
+      <classWitsml>weight on bit (average)</classWitsml>
+      <unit>klbf</unit>
+      <mnemAlias>wobAv</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Weight on bit</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-8">
+      <mnemonic>HKLD</mnemonic>
+      <classWitsml>hookload (average)</classWitsml>
+      <unit>klbf</unit>
+      <mnemAlias>hkldAv</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Hookload</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-9">
+      <mnemonic>Surf RPM</mnemonic>
+      <classWitsml>rotary speed (average)</classWitsml>
+      <unit>rpm</unit>
+      <mnemAlias>rpmAv</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>RPM measured at surface</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-10">
+      <mnemonic>Mtr RPM</mnemonic>
+      <classWitsml>measured motor speed</classWitsml>
+      <unit>rpm</unit>
+      <mnemAlias>mmrpm</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Calculated motor RPM</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-11">
+      <mnemonic>Avg TQ</mnemonic>
+      <classWitsml>torque (average)</classWitsml>
+      <unit>kft.lbf</unit>
+      <mnemAlias>tqAv</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Average drilling torque</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-12">
+      <mnemonic>Max TQ</mnemonic>
+      <classWitsml>torque (maximum)</classWitsml>
+      <unit>kft.lbf</unit>
+      <mnemAlias>torque (maximum)</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Maximum drilling torque</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-13">
+      <mnemonic>Min TQ</mnemonic>
+      <classWitsml>torque (average)</classWitsml>
+      <unit>kft.lbf</unit>
+      <mnemAlias>tqMn</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Minimum drilling torque</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-14">
+      <mnemonic>Max - Min TQ</mnemonic>
+      <classWitsml>torque (maximum)</classWitsml>
+      <unit>kft.lbf</unit>
+      <mnemAlias>tqMx-Mn</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Maximum - minimum drilling torque</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-15">
+      <mnemonic>Max - Min TQ</mnemonic>
+      <classWitsml>flow rate in (average)</classWitsml>
+      <unit>galUS/min</unit>
+      <mnemAlias>flowInAv</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Average mud flow in</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-16">
+      <mnemonic>Pump p avg</mnemonic>
+      <classWitsml>pressure at pump (average)</classWitsml>
+      <unit>galUS/min</unit>
+      <mnemAlias>presPumpAv</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Average pump pressure</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-17">
+      <mnemonic>Mud D avg</mnemonic>
+      <classWitsml>mud density in (average)</classWitsml>
+      <unit>g/cm3</unit>
+      <mnemAlias>wtMudInAv</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Average mud density</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-18">
+      <mnemonic>Mud Temp avg</mnemonic>
+      <classWitsml>mud temperature in (average)</classWitsml>
+      <unit>degC</unit>
+      <mnemAlias>tempMudInAv</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Average mud temperature</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-19">
+      <mnemonic>Bit RPM</mnemonic>
+      <classWitsml>rotary speed (average)</classWitsml>
+      <unit>rpm</unit>
+      <mnemAlias>rpmBitAv</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>Bit RPM</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-20">
+      <mnemonic>DXC</mnemonic>
+      <classWitsml>drilling exponent (corrected)</classWitsml>
+      <mnemAlias>dxc</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>d exponent</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logCurveInfo uid="lci-21">
+      <mnemonic>ECD</mnemonic>
+      <classWitsml>ecdTd ???????????</classWitsml>
+      <unit>g/cm3</unit>
+      <mnemAlias>ecdTd</mnemAlias>
+      <nullValue>-999.25</nullValue>
+      <minIndex uom="m">499</minIndex>
+      <maxIndex uom="m">509.01</maxIndex>
+      <curveDescription>equivalent circulating density</curveDescription>
+      <sensorOffset uom="m">0</sensorOffset>
+      <traceState>raw</traceState>
+      <typeLogData>double</typeLogData>
+    </logCurveInfo>
+    <logData>
+      <mnemonicList>Mdepth,Vdepth,Bit Dist,TQ on btm,TQ off btm,ROP,WOP,HKLD,Surf RPM,Mtr RPM,Avg TQ,Max TQ,Min TQ,Max - Min TQ,Max - Min TQ,Pump p avg,Mud D avg,Mud Temp avg,Bit RPM,DXC,ECD</mnemonicList>
+      <unitList>m,m,m,kft.lbf,kft.lbf,m/h,klbf,klbf,rpm,rpm,kft.lbf,kft.lbf,kft.lbf,kft.lbf,galUS,galUS,g/cm3,degC,rpm,,g/cm3</unitList>
+      <data>499,498.99,1.25,0,1.45,3.67,11.02,187.66,0.29,116.24,0.01,0.05,0.01,0,886.03,1089.99,1.11,14.67,0.29,1.12,1.11</data>
+      <data>500.01,500,1.9,0.01,1.42,9.94,11.32,185.7,0.29,116.24,0.01,0.01,0.01,0,795.19,973.48,1.11,14.67,0.29,0.95,1.11</data>
+      <data>501.03,501.02,2.92,0.02,1.41,20.46,11.62,184.23,0.29,120,0.01,0.01,0.01,0,796.68,956.25,1.11,14.67,0.29,0.83,1.11</data>
+      <data>502.01,502,3.9,0.06,1.44,21.73,10.37,185.49,0.29,120,0.01,0.01,0.01,0,802.96,1005.68,1.1,14.66,0.3,0.8,1.11</data>
+      <data>503.01,503,4.9,0.11,1.48,17.65,10.31,185.55,0.29,118.09,0.01,0.01,0.01,0,801.19,1007.77,1.11,14.66,0.3,0.83,1.11</data>
+      <data>504.05,504.04,5.94,0.18,1.55,15.58,10.4,185.43,0.29,120,0.01,0.01,0.01,0,800.83,1015.89,1.1,14.67,0.29,0.86,1.11</data>
+      <data>505.03,505.00,612.03,1.83,3.32,37.11,18.5,243.38,91.93,0,8.07,8.35,7.68,0.19,900.07,3205,1.26,29.67,93.74,0.75,1.31</data>
+      <data>506.04,505.95,613.04,1.9,3.4,9.85,27.79,233.9,79,0,8.31,10.24,6.83,1.02,907.9,3210,1.26,29.8,95,1.09,1.31</data>
+      <data>507.04,506.91,614.04,1.97,3.46,32.44,23.13,238.59,77.35,0,7.93,8.96,7.76,0.14,911.55,3223.33,1.26,29.88,89.19,0.78,1.31</data>
+      <data>508.01,507.84,615.01,2,3.49,29.03,19.38,242.36,90.59,0,8.32,8.78,7.76,0.32,899.74,3222.17,1.26,29.95,91.66,0.8,1.31</data>
+      <data>509.01,508.75,616.01,2.08,3.54,13.09,15.89,245.92,93.38,0,7.62,11.87,6.43,0.86,900.93,3215.78,1.26,30.06,98.51,0.92,1.31</data>
+    </logData>
+    <commonData>
+      <dTimCreation>2003-11-24T08:15:00.000Z</dTimCreation>
+      <dTimLastChange>2003-11-24T08:17:00.000Z</dTimLastChange>
+      <itemState>plan</itemState>
+      <comments>These are the comments associated with the log object.</comments>
+    </commonData>
+  </log>
+</logs>


### PR DESCRIPTION
This PR resolves #423 by adding the equivalence overrides for the channel and channel set objects.