### PR TITLE
fixed bad unit for time index channel

### DIFF
--- a/df-valve/src/test/resources/dotConversion/log1411Time.xml
+++ b/df-valve/src/test/resources/dotConversion/log1411Time.xml
@@ -23,7 +23,7 @@
         <logCurveInfo uid="lci-1">
             <mnemonic>Time</mnemonic>
             <classWitsml>time</classWitsml>
-            <unit>m</unit>
+            <unit>s</unit>
             <mnemAlias>md</mnemAlias>
             <nullValue>-999.25</nullValue>
             <minDateTimeIndex>2001-06-18T13:20:00Z</minDateTimeIndex>
@@ -295,7 +295,7 @@
         </logCurveInfo>
         <logData>
             <mnemonicList>Time,DVER,DBTM,DTOR_RT,TQLS,ROP,SWOB,HKLD,RPM,TRPM,TQA,TQX,TQBX,TQMX,MFOP,SPPA,BEDC,MTOA,IMSA,DXC,ECD_RT</mnemonicList>
-            <unitList>m,m,m,kft.lbf,kft.lbf,m/h,klbf,klbf,rpm,rpm,kft.lbf,kft.lbf,kft.lbf,kft.lbf,galUS/min,galUS/min,g/cm3,degC,rpm,unitless,g/cm3</unitList>
+            <unitList>s,m,m,kft.lbf,kft.lbf,m/h,klbf,klbf,rpm,rpm,kft.lbf,kft.lbf,kft.lbf,kft.lbf,galUS/min,galUS/min,g/cm3,degC,rpm,unitless,g/cm3</unitList>
             <data>2001-06-18T13:20:00Z,498.99,1.25,0,1.45,3.67,11.02,187.66,0.29,116.24,0.01,0.05,0.01,0,886.03,1089.99,1.11,14.67,0.29,1.12,1.11</data>
             <data>2001-06-18T13:30:00.01Z,500,1.9,0.01,1.42,9.94,11.32,185.7,0.29,116.24,0.01,0.01,0.01,0,795.19,973.48,1.11,14.67,0.29,0.95,1.11</data>
             <data>2001-06-18T13:40:00.03Z,501.02,2.92,0.02,1.41,20.46,11.62,184.23,0.29,120,0.01,0.01,0.01,0,796.68,956.25,1.11,14.67,0.29,0.83,1.11</data>


### PR DESCRIPTION
Updated channel metadata and unit list to 's' from 'm' for the Time index.

Thank you for submitting a contribution to Drillflow.

In order to streamline the review of the contribution please
ensure the following steps have been taken:

### For all changes:
- [ ] Is there a Github ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with DF-XXXX where XXXX is the waffle number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn clean install at the root Drillflow folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you updated Soap UI
- [ ] Have you ensured that all Soap UI test cases pass
- [ ] Have you added documentation for any API related changes to the /docs folder

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
