### PR TITLE
This PR to Fix df-551

### DIFF
--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/LogConverterExtended.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/LogConverterExtended.java
@@ -69,8 +69,15 @@ public class LogConverterExtended extends com.hashmapinc.tempus.WitsmlObjects.Ut
         log.setNameWell(getWellName( wellSearchEndpoint,client,  username,password,  exchangeID,witsmlObject));
         log.setNameWellbore(getWelBorelName( wellBoreSearchEndpoint,client,  username, password,  exchangeID,witsmlObject));
 
-        List<com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo> lcis = Channel.to1411(channels);
-        log.setLogCurveInfo(lcis);
+
+        if (((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog)witsmlObject).getLogData().size() > 0){
+            List<com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo> lcis = Channel.to1411(channels);
+            log.setLogCurveInfo(lcis);
+        }else{
+            List<com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo> lcis = Channel.to1411NoLogData(channels,cs.get(0));
+            log.setLogCurveInfo(lcis);
+        }
+
         // Code added to build log data response
         //Todo construct LogData from response
 

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channel/Channel.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/model/log/channel/Channel.java
@@ -803,6 +803,69 @@ public class Channel {
         return curves;
     }
 
+    public static List<com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo> to1411NoLogData(
+            List<Channel> channels,ChannelSet channelSet) {
+        List<com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo> curves = new ArrayList<>();
+
+        if (channels == null || channels.isEmpty())
+            return null;
+
+        for (Channel c : channels) {
+            try{
+                com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo lci =
+                        new com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo();
+                ShortNameStruct name = new ShortNameStruct();
+                name.setValue(c.getMnemonic());
+                name.setNamingSystem(c.getNamingSystem());
+                lci.setMnemonic(name);
+                lci.setAlternateIndex(c.getAlternateIndex());
+                lci.setClassWitsml(c.getClassWitsml());
+                //NOTE: WE WILL ALWAYS SET THE INDEX TO THE FIRST COLUMN
+                lci.setCurveDescription(c.getCitation().getDescription());
+                lci.setDataSource(c.getSource());
+                lci.setTraceOrigin(c.getTraceOrigin());
+                lci.setTraceState(c.getTraceState());
+                lci.setTypeLogData(c.getDataType());
+                lci.setUid(c.getUid());
+                lci.setUnit(c.getUom());
+                lci.setNullValue(c.getNullValue());
+                lci.setMnemAlias(MnemAlias.to1411(c.mnemAlias));
+                lci.setAxisDefinition(AxisDefinition.to1411(c.getAxisDefinition()));
+                lci.setDensData(DensData.to1411(c.getDensData()));
+                lci.setSensorOffset(SensorOffset.to1411(c.getSensorOffset()));
+                lci.setWellDatum(WellDatum.to1411(c.getWellDatum()));
+                lci.setClassIndex(c.getClassIndex());
+                if (c.getTimeDepth().toLowerCase().contains("time")){
+                    if (c.getStartIndex() != null)
+                        lci.setMinDateTimeIndex(convertIsoDateToXML(c.getStartIndex()));
+                    if (c.getEndIndex() != null)
+                        lci.setMaxDateTimeIndex(convertIsoDateToXML(c.getEndIndex()));
+                } else {
+                    if (channelSet.getStartIndex() != null){
+                        com.hashmapinc.tempus.WitsmlObjects.v1411.GenericMeasure minMeasure =
+                                new com.hashmapinc.tempus.WitsmlObjects.v1411.GenericMeasure();
+                        minMeasure.setUom("m");
+                        minMeasure.setValue(Double.parseDouble(channelSet.getStartIndex()));
+                        lci.setMinIndex(minMeasure);
+                    }
+                    if (channelSet.getEndIndex() != null){
+                        com.hashmapinc.tempus.WitsmlObjects.v1411.GenericMeasure maxMeasure =
+                                new com.hashmapinc.tempus.WitsmlObjects.v1411.GenericMeasure();
+                        maxMeasure.setUom("m");
+                        maxMeasure.setValue(Double.parseDouble(channelSet.getEndIndex()));
+                        lci.setMaxIndex(maxMeasure);
+                    }
+                }
+                //Need to address this in wol...does not exist
+                //lci.getExtensionNameValue()
+                curves.add(lci);
+            } catch (Exception ex){
+                continue;
+            }
+        }
+        return curves;
+    }
+
     public static List<com.hashmapinc.tempus.WitsmlObjects.v1311.CsLogCurveInfo> to1311(
             List<Channel> channels) {
         List<com.hashmapinc.tempus.WitsmlObjects.v1311.CsLogCurveInfo> curves = new ArrayList<>();


### PR DESCRIPTION
This PR to fix df-551 - 

The start and end index is missing as they don’t store the index as a separate channel. The start and end of the depth index would have to equal the start and end index of the channelset…obviously this is only for the case where the logData is not requested. In that case, the start/end would reflect what is in the return.

In order to streamline the review of the contribution please
ensure the following steps have been taken:

### For all changes:
- [X] Is there a Github ticket associated with this PR? Is it referenced 
     in the commit message?

- [X ] Does your PR title start with DF-XXXX where XXXX is the waffle number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ X] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For code changes:
- [ X] Have you ensured that the full suite of tests is executed via mvn clean install at the root Drillflow folder?
- [X ] Have you written or updated unit tests to verify your changes?
- [ X] Have you updated Soap UI
- [X ] Have you ensured that all Soap UI test cases pass
- [ X] Have you added documentation for any API related changes to the /docs folder

### For documentation related changes:
- [X ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
