### PR TITLE
df-682: removing the api key requirement

### DIFF
--- a/df-server/src/main/resources/application.yml
+++ b/df-server/src/main/resources/application.yml
@@ -21,7 +21,6 @@ server:
 valve : 
     name: DoT
     configuration :
-        apikey: ${VALVE_API_KEY}
         token.path: ${TOKEN_PATH:https://api-demo.nam.drillops.slb.com/democore/BasicAuth/v1/token/}
         well.path: ${WELL_PATH:https://api-demo.nam.drillops.slb.com/democore/well/v2/witsml/wells/}
         well.gql.path: ${WELL_GQL_PATH:https://api-demo.nam.drillops.slb.com/democore/well/v2/graphql/}

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/DotValve.java
@@ -49,10 +49,9 @@ public class DotValve implements IValve {
 	 * @throws ValveAuthException
 	 */
 	public DotValve(Map<String, String> config) throws ValveAuthException  {
-		String apikey = config.get("apikey");
 		String tokenPath = config.get("token.path");
 
-		this.CLIENT = new DotClient(apikey, tokenPath);
+		this.CLIENT = new DotClient(tokenPath);
 		this.DELEGATOR = new DotDelegator(config);
 
 		LOG.info(ValveLogging.getLogMsg("Creating valve pointing to url: " + tokenPath));

--- a/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/DotClient.java
+++ b/df-valve/src/main/java/com/hashmapinc/tempus/witsml/valve/dot/client/DotClient.java
@@ -48,8 +48,6 @@ public class DotClient {
     private static final Logger LOG = Logger.getLogger(DotClient.class.getName());
     //private final String URL;
     private final String TOKEN_PATH;
-    private final String API_KEY;
-    // changed to ConcurrentHashMap to make thread safe
     private ConcurrentHashMap<String, DecodedJWT> cache;
 
     /**
@@ -58,8 +56,7 @@ public class DotClient {
      * @param API_KEY
      * @throws ValveAuthException
      */
-    public DotClient(String API_KEY, String tokenPath)  throws ValveAuthException{
-        this.API_KEY = API_KEY;
+    public DotClient(String tokenPath)  throws ValveAuthException{
         this.TOKEN_PATH = tokenPath;
         // changed to ConcurrentHashMap to make thread safe
         this.cache = new ConcurrentHashMap<String, DecodedJWT>();
@@ -83,7 +80,6 @@ public class DotClient {
             // build request
             HttpRequestWithBody req = Unirest.post(this.TOKEN_PATH);
             req.header("Content-Type", "application/json")
-                .header("X-Api-Key", this.API_KEY)
                 .body(payload);
 
             // send request

--- a/docs/source/integration/dot/envvars.rst
+++ b/docs/source/integration/dot/envvars.rst
@@ -10,17 +10,6 @@ Introduction
 
 There are several environment variables that are used in configuring the DrillFlow DoT Valve.
 
-:Variable:
-    VALVE_API_KEY
-:Description:
-    The API key to be used to authenticate against the API gateway.
-:Default:
-    No Default
-:Required:
-    YES
-:Example Environmental Switch in Docker:
-    To set to xyz : -e VALVE_API_KEY='xyz'
-
 ==============
 Path Variables
 ==============


### PR DESCRIPTION
This PR resolves #682 

Currently the solution requires the API key to be present to convert the Basic authentication to a JWT token provided by prism. This is not required anymore, and as such should be removed from the Drillflow DOT valve.

This PR removes it by taking the following steps:

1) Removing it from the DoTClient (as a function of the token refresh function)
2) Changing the DotClient instantiation by removing the need for the api key
3) Removing the api key from the application.yml
4) Removing the api key from the documentation

This was tested against the DrillOps town DemoCore API on Aug 22 and found to be working.

Thank you for submitting a contribution to Drillflow.

In order to streamline the review of the contribution please
ensure the following steps have been taken:

### For all changes:
- [x] Is there a Github ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with DF-XXXX where XXXX is the waffle number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root Drillflow folder?
- [x] Have you written or updated unit tests to verify your changes?
- [n/a] Have you updated Soap UI
- [x] Have you ensured that all Soap UI test cases pass
- [x] Have you added documentation for any API related changes to the /docs folder

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.